### PR TITLE
add: CN/TT pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -850,6 +850,10 @@
             "name" : "BTC.TOP",
             "link" : "http://btc.top"
         },
+        "3QLeXx1J9Tp3TBnQyHrhVxne9KqkAS9JSR" : {
+            "name" : "CN/TT",
+            "link" : ""
+        },
         "1Afcpc2FpPnREU6i52K3cicmHdvYRAH9Wo" : {
             "name" : "CANOE",
             "link" : "https://www.canoepool.com"


### PR DESCRIPTION
This pool was active between block height 578638 and 622859. The real entity behind the pool is unknown, however all have CN/TT as coinbase tag. All coinbase outputs were created to 3QLeXx1J9Tp3TBnQyHrhVxne9KqkAS9JSR.