### PR TITLE
add: 1FeDtF.. -> BitFury

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -906,6 +906,10 @@
             "name": "Huobi.pool",
             "link": "https://www.poolhb.com/"
         },
+        "1FeDtFhARLxjKUPPkQqEBL78tisenc9znS" : {
+            "name" : "BitFury",
+            "link" : "http://bitfury.com/"
+        },
         "1M1Xw2rczxkF3p3wiNHaTmxvbpZZ7M6vaa" : {
             "name": "1M1X",
             "link": ""


### PR DESCRIPTION
BitFury only started to include the coinbase tag "/BitFury/" with block 352363 but always mined to the address 1FeDtFhARLxjKUPPkQqEBL78tisenc9znS.