### PR TITLE
add: 1Nd99aNg.. -> BitFury

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -594,6 +594,10 @@
             "name" : "BitFury",
             "link" : "http://bitfury.com/"
         },
+        "1Nd99aNgYWpKkqcqSMgWtdtVDadewAS5F7" : {
+            "name" : "BitFury",
+            "link" : "http://bitfury.com/"
+        },
         "1BX5YoLwvqzvVwSrdD4dC32vbouHQn2tuF" : {
             "name" : "Cointerra",
             "link" : "http://cointerra.com/"


### PR DESCRIPTION
The pool mining with the address 1Nd99aNgYWpKkqcqSMgWtdtVDadewAS5F7 later became known as Bitfury. 
They share the same coinbase messages as an address that later used the coinbase tag `BitFury`.

See also: https://github.com/0xB10C/known-mining-pools/pull/8
See also: https://github.com/bitpay/insight-api/blob/88b8f8786afa6887815f6b0baa84204cdc256b6c/pools.json#L39-L44