### PR TITLE
add: 3DXfe.. and 35qGB.. -> Poolin

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -922,6 +922,14 @@
             "name" : "Poolin",
             "link" : "https://www.poolin.com/"
         },
+        "35qGBQsRQb8CSUzcSWktMykeA6zm5iCEJJ" : {
+            "name" : "Poolin",
+            "link" : "https://www.poolin.com/"
+        },
+        "3DXfeMBimuvN3TWnQXDhr47P8M8yxMy9Pd" : {
+            "name" : "Poolin",
+            "link" : "https://www.poolin.com/"
+        },
         "12Taz8FFXQ3E2AGn3ZW1SZM5bLnYGX4xR6" : {
             "name" : "Tangpool",
             "link" : "http://www.tangpool.com/"


### PR DESCRIPTION
35qGBQsRQb8CSUzcSWktMykeA6zm5iCEJJ and 3DXfeMBimuvN3TWnQXDhr47P8M8yxMy9Pd belong to the same wallet.

This wallet belongs to Poolin, as visible in the coinbase transaction from the newer address 36n452uGq1x4mK7bfyZR8wgE47AnBb2pzi belonging to the same wallet. 

https://www.walletexplorer.com/wallet/009b95d4e0011c38/addresses