### PR TITLE
add:  Ukrpool.com, 125K2xfi..-> UKRPool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -24,6 +24,10 @@
             "name": "Bitfarms",
             "link": "https://www.bitarms.io/"
         },
+        "Ukrpool.com": {
+            "name": "UKRPool",
+            "link": "https://ukrpool.com/"
+        },
         "/Huobi/": {
             "name": "Huobi.pool",
             "link": "https://www.poolhb.com/"
@@ -817,6 +821,10 @@
         "19qa95rTbDziNCS9EexUbh2hVY4viUU9tt" : {
             "name" : "HAOZHUZHU",
             "link" : "http://haozhuzhu.com"
+        },
+        "125K2xfiBdae42gSKiCGwi85Frpy1vHmGj": {
+            "name": "UKRPool",
+            "link": "https://ukrpool.com/"
         },
         "1AZ6BkCo4zgTuuLpRStJH8iNsehXTMp456" : {
             "name" : "BitcoinIndia",


### PR DESCRIPTION
UKRPool used the address 125K2xfiBdae42gSKiCGwi85Frpy1vHmGj and the coinbase tag `Ukrpool.com`.

The same address was later used by with the tag `hash.okkong.com`. See: ff7aa4a53cef6907fb0ddc00447184df63fbcf3eb1b961ad9092e6eb6c8cae89