### PR TITLE
add: 1Ca1KNQ -> BTC Pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -614,6 +614,10 @@
             "name" : "BitFury",
             "link" : "http://bitfury.com/"
         },
+        "1Ca1KNQQo8akbrwTjjXuk8aikvC2pwodU2" : {
+            "name" : "BTCPool",
+            "link" : ""
+        },
         "1BX5YoLwvqzvVwSrdD4dC32vbouHQn2tuF" : {
             "name" : "Cointerra",
             "link" : "http://cointerra.com/"


### PR DESCRIPTION
All coinbase transactions with the output address 1Ca1KNQQo8akbrwTjjXuk8aikvC2pwodU2 contain the coinbase tag `BTCPool`.

The website for BTCPool is unknown.