### PR TITLE
add: /E2M/ -> WAYI.CN

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -44,6 +44,10 @@
             "name": "WAYI.CN",
             "link": "https://www.easy2mine.com/"
         },
+        "/E2M/": {
+            "name": "WAYI.CN",
+            "link": "http://www.easy2mine.com/"
+        },
         "/canoepool/": {
             "name": "CanoePool",
             "link": "https://www.canoepool.com/"


### PR DESCRIPTION
This pool mined e.g. 00000000000000000003256ad9a22dd95b6ceaeb2377068040cc101fcf14d93c
and 00000000000000000008c659de6cae2595e4de6e9fb008e5a6aa65a8cc0ecf06 recently.

The self-reported BTC hashrate on easy2mine.com of just over 1 EH/s fits in regards to blocks found per day.