### PR TITLE
 Remove superfluous space in address field

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -646,7 +646,7 @@
             "name" : "BitMinter",
             "link" : "https://bitminter.com/"
         },
-        "15xiShqUqerfjFdyfgBH1K7Gwp6cbYmsTW " : {
+        "15xiShqUqerfjFdyfgBH1K7Gwp6cbYmsTW" : {
             "name" : "EclipseMC",
             "link" : "https://eclipsemc.com/"
         },


### PR DESCRIPTION
Addresses are most probably matched by whole strings. An extra space in the field will throw off some old block attribution. (f.e. mempool.space)