### PR TITLE
Add binance/ pattern

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -516,6 +516,10 @@
             "name" : "Binance Pool",
             "link" : "https://pool.binance.com/"
         },
+        "binance/": {
+            "name" : "Binance Pool",
+            "link" : "https://pool.binance.com/"
+        },
         "/Minerium.com/" : {
             "name" : "Minerium",
             "link" : "https://www.minerium.com/"


### PR DESCRIPTION
A bunch of Binance coinbase messages take the form of `binance/or...`, `binance/fr....`. Notably without a `/` prefix.

<img width="584" alt="Schermafbeelding 2021-05-31 om 15 41 56" src="https://user-images.githubusercontent.com/10217/120202339-c683bc00-c226-11eb-9408-f5af78142fdc.png">

https://btc.com/000000000000000000021ccf3fd7e6e507633f62ffdda3640e487de9037f7e67