### PR TITLE
add: TogetherPool and Poolin

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -562,7 +562,7 @@
        	},
         "TogetherPool": {
             "name": "TogetherPool",
-            "link": ""
+            "link": "https://www.togetherpool.com"
         }
     },
     "payout_addresses" : {
@@ -1120,7 +1120,7 @@
         },
         "bc1qwlrsvgtn99rqp3fgaxq6f6jkgms80rnej0a8tc": {
             "name": "TogetherPool",
-            "link": ""
+            "link": "https://www.togetherpool.com"
         },
         "1QEiAhdHdMhBgVbDM7zUXWGkNhgEEJ6uLd": {
             "name": "ArkPool",

--- a/pools.json
+++ b/pools.json
@@ -995,8 +995,8 @@
             "link" : "https://bitfury.com/"
         },
         "1M1Xw2rczxkF3p3wiNHaTmxvbpZZ7M6vaa" : {
-            "name": "1M1X",
-            "link": ""
+            "name": "Poolin",
+            "link": "https://www.poolin.com"
         },
         "39m5Wvn9ZqyhYmCYpsyHuGMt5YYw4Vmh1Z" : {
             "name": "BytePool",


### PR DESCRIPTION
Updated the website for TogetherPool and changed 1M1X to Poolin according to the [pools.json](https://github.com/blockchain/Blockchain-Known-Pools/blob/master/pools.json) list from Blockchain.com.