### PR TITLE
add: bc1q7wedv4zdu5... -> f2pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -670,6 +670,10 @@
             "name" : "F2Pool",
             "link" : "https://www.f2pool.com/"
         },
+        "bc1q7wedv4zdu5smt3shljpu5mgns48jn299mukymc" : {
+            "name" : "F2Pool",
+            "link" : "https://www.f2pool.com/"
+        },
         "3HuobiNg2wHjdPU2mQczL9on8WF7hZmaGd" : {
             "name" : "Huobi Pool",
             "link" : "https://www.hpt.com/"


### PR DESCRIPTION
Reasoning:
1. paid >388 BTC to known F2Pool address in ba1a127619f471198673e057bf20097588525dfe0bf1281009c70a1a6afb5367
2. includes zero-fee transactions (commonly done by f2pool)
3. zero-fee transactions are
  a) a f2pool payout: https://oxt.me/transaction/6af178a9918940c7643a7f8c5468bbec207e8fce38674a6da34729ea96c5cb1a
  b) a f2pool-owned coinbase consolidation: https://oxt.me/transaction/676bce7029a589a1525cccd01ca1c0d4387189989e8691c7ef57ab3bbfe3f090

Closes #45