### PR TITLE
Only one link per pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ folder. For each pool, the following information is included in the JSON file:
     "/example/",
     "Example Pool"
   ],
-  "links": [
-    "https://example.com"
-  ]
+  "link": "https://example.com"
 }
 ```
 

--- a/contrib/create-old-pools-json.py
+++ b/contrib/create-old-pools-json.py
@@ -19,9 +19,7 @@ for file_path in entity_files:
     with open(file_path, "r") as f:
         e = json.load(f)
         name = e["name"]
-        link = ""
-        if len(e["links"]) > 0:
-            link = e["links"][0]
+        link = e["link"]
         for addr in e["addresses"]:
             addresses[addr] = { "name": name, "link": link }
         for tag in e["tags"]:

--- a/generated/pools.json
+++ b/generated/pools.json
@@ -414,7 +414,7 @@
     },
     "1GP8eWArgpwRum76saJS4cZKCHWJHs9PQo": {
       "name": "CanoePool",
-      "link": "https://btc.canoepool.com"
+      "link": "https://canoepool.com"
     },
     "1GRcX882sdBYCAWyG99iF2oz7j3nYzXhLM": {
       "name": "AntPool",
@@ -666,7 +666,7 @@
     },
     "3GvEGtnvgeBJ3p3EpdZhvUkxY4pDARkbjd": {
       "name": "Bitfarms",
-      "link": "https://www.bitarms.io"
+      "link": "https://www.bitfarms.io"
     },
     "3HuobiNg2wHjdPU2mQczL9on8WF7hZmaGd": {
       "name": "Huobi Pool",
@@ -836,7 +836,7 @@
     },
     "/CANOE/": {
       "name": "CanoePool",
-      "link": "https://btc.canoepool.com"
+      "link": "https://canoepool.com"
     },
     "/ConnectBTC - Home for Miners/": {
       "name": "ConnectBTC",
@@ -968,7 +968,7 @@
     },
     "/canoepool/": {
       "name": "CanoePool",
-      "link": "https://btc.canoepool.com"
+      "link": "https://canoepool.com"
     },
     "/ckpool.org/": {
       "name": "CKPool",
@@ -1064,7 +1064,7 @@
     },
     "BITFARMS": {
       "name": "Bitfarms",
-      "link": "https://www.bitarms.io"
+      "link": "https://www.bitfarms.io"
     },
     "BTC Guild": {
       "name": "BTC Guild",

--- a/pools/175btc.json
+++ b/pools/175btc.json
@@ -4,7 +4,5 @@
   "tags": [
     "Mined By 175btc.com"
   ],
-  "links": [
-    "https://www.175btc.com"
-  ]
+  "link": "https://www.175btc.com"
 }

--- a/pools/1hash.json
+++ b/pools/1hash.json
@@ -6,7 +6,5 @@
   "tags": [
     "Mined by 1hash.com"
   ],
-  "links": [
-    "https://www.1hash.com"
-  ]
+  "link": "https://www.1hash.com"
 }

--- a/pools/1thash.json
+++ b/pools/1thash.json
@@ -8,7 +8,5 @@
     "/1THash&58COIN/",
     "/1THash/"
   ],
-  "links": [
-    "https://www.1thash.top"
-  ]
+  "link": "https://www.1thash.top"
 }

--- a/pools/21-inc.json
+++ b/pools/21-inc.json
@@ -8,7 +8,5 @@
   "tags": [
     "/pool34/"
   ],
-  "links": [
-    "https://21.co"
-  ]
+  "link": "https://21.co"
 }

--- a/pools/50btc.json
+++ b/pools/50btc.json
@@ -4,7 +4,5 @@
   "tags": [
     "50BTC"
   ],
-  "links": [
-    "https://www.50btc.com"
-  ]
+  "link": "https://www.50btc.com"
 }

--- a/pools/58coin.json
+++ b/pools/58coin.json
@@ -6,7 +6,5 @@
   "tags": [
     "/58coin.com/"
   ],
-  "links": [
-    "https://www.58coin.com"
-  ]
+  "link": "https://www.58coin.com"
 }

--- a/pools/7pool.json
+++ b/pools/7pool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/$Mined by 7pool.com/"
   ],
-  "links": [
-    "https://7pool.com"
-  ]
+  "link": "https://7pool.com"
 }

--- a/pools/8baochi.json
+++ b/pools/8baochi.json
@@ -6,7 +6,5 @@
   "tags": [
     "/八宝池 8baochi.com/"
   ],
-  "links": [
-    "https://8baochi.com"
-  ]
+  "link": "https://8baochi.com"
 }

--- a/pools/a-xbt.json
+++ b/pools/a-xbt.json
@@ -6,7 +6,5 @@
   "tags": [
     "/A-XBT/"
   ],
-  "links": [
-    "https://www.a-xbt.com"
-  ]
+  "link": "https://www.a-xbt.com"
 }

--- a/pools/aao-pool.json
+++ b/pools/aao-pool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/AAOPOOL/"
   ],
-  "links": [
-    "https://btc.tmspool.top"
-  ]
+  "link": "https://btc.tmspool.top"
 }

--- a/pools/antpool.json
+++ b/pools/antpool.json
@@ -30,7 +30,5 @@
     "/AntPool/",
     "Mined by AntPool"
   ],
-  "links": [
-    "https://www.antpool.com"
-  ]
+  "link": "https://www.antpool.com"
 }

--- a/pools/arkpool.json
+++ b/pools/arkpool.json
@@ -6,5 +6,5 @@
   "tags": [
     "/ArkPool/"
   ],
-  "links": []
+  "link": ""
 }

--- a/pools/asicminer.json
+++ b/pools/asicminer.json
@@ -4,7 +4,5 @@
   "tags": [
     "ASICMiner"
   ],
-  "links": [
-    "https://www.asicminer.co"
-  ]
+  "link": "https://www.asicminer.co"
 }

--- a/pools/batpool.json
+++ b/pools/batpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/BATPOOL/"
   ],
-  "links": [
-    "https://www.batpool.com"
-  ]
+  "link": "https://www.batpool.com"
 }

--- a/pools/bcmonster.json
+++ b/pools/bcmonster.json
@@ -6,7 +6,5 @@
   "tags": [
     "/BCMonster/"
   ],
-  "links": [
-    "https://www.bcmonster.com"
-  ]
+  "link": "https://www.bcmonster.com"
 }

--- a/pools/bcpool-io.json
+++ b/pools/bcpool-io.json
@@ -4,7 +4,5 @@
   "tags": [
     "bcpool.io"
   ],
-  "links": [
-    "https://bcpool.io"
-  ]
+  "link": "https://bcpool.io"
 }

--- a/pools/binance-pool.json
+++ b/pools/binance-pool.json
@@ -14,7 +14,5 @@
     "binance.com/",
     "binance/"
   ],
-  "links": [
-    "https://pool.binance.com"
-  ]
+  "link": "https://pool.binance.com"
 }

--- a/pools/bitalo.json
+++ b/pools/bitalo.json
@@ -4,7 +4,5 @@
   "tags": [
     "Bitalo"
   ],
-  "links": [
-    "https://bitalo.com/mining"
-  ]
+  "link": "https://bitalo.com/mining"
 }

--- a/pools/bitclub.json
+++ b/pools/bitclub.json
@@ -6,7 +6,5 @@
   "tags": [
     "/BitClub Network/"
   ],
-  "links": [
-    "https://bitclubpool.com"
-  ]
+  "link": "https://bitclubpool.com"
 }

--- a/pools/bitcoin-affiliate-network.json
+++ b/pools/bitcoin-affiliate-network.json
@@ -4,7 +4,5 @@
   "tags": [
     "bitcoinaffiliatenetwork.com"
   ],
-  "links": [
-    "https://mining.bitcoinaffiliatenetwork.com"
-  ]
+  "link": "https://mining.bitcoinaffiliatenetwork.com"
 }

--- a/pools/bitcoin-com.json
+++ b/pools/bitcoin-com.json
@@ -4,7 +4,5 @@
   "tags": [
     "pool.bitcoin.com"
   ],
-  "links": [
-    "https://www.bitcoin.com"
-  ]
+  "link": "https://www.bitcoin.com"
 }

--- a/pools/bitcoin-india.json
+++ b/pools/bitcoin-india.json
@@ -4,7 +4,5 @@
   "tags": [
     "/Bitcoin-India/"
   ],
-  "links": [
-    "https://bitcoin-india.org"
-  ]
+  "link": "https://bitcoin-india.org"
 }

--- a/pools/bitcoin-ukraine.json
+++ b/pools/bitcoin-ukraine.json
@@ -4,7 +4,5 @@
   "tags": [
     "/Bitcoin-Ukraine.com.ua/"
   ],
-  "links": [
-    "https://bitcoin-ukraine.com.ua"
-  ]
+  "link": "https://bitcoin-ukraine.com.ua"
 }

--- a/pools/bitcoinindia.json
+++ b/pools/bitcoinindia.json
@@ -4,7 +4,5 @@
     "1AZ6BkCo4zgTuuLpRStJH8iNsehXTMp456"
   ],
   "tags": [],
-  "links": [
-    "https://pool.bitcoin-india.org"
-  ]
+  "link": "https://pool.bitcoin-india.org"
 }

--- a/pools/bitcoinrussia.json
+++ b/pools/bitcoinrussia.json
@@ -7,7 +7,5 @@
   "tags": [
     "/Bitcoin-Russia.ru/"
   ],
-  "links": [
-    "https://bitcoin-russia.ru"
-  ]
+  "link": "https://bitcoin-russia.ru"
 }

--- a/pools/bitdeer.json
+++ b/pools/bitdeer.json
@@ -4,7 +4,5 @@
   "tags": [
     "Bitdeer"
   ],
-  "links": [
-    "https://www.bitdeer.com"
-  ]
+  "link": "https://www.bitdeer.com"
 }

--- a/pools/bitfarms.json
+++ b/pools/bitfarms.json
@@ -6,8 +6,5 @@
   "tags": [
     "BITFARMS"
   ],
-  "links": [
-    "https://www.bitarms.io",
-    "https://www.bitfarms.io"
-  ]
+  "link": "https://www.bitfarms.io"
 }

--- a/pools/bitfury.json
+++ b/pools/bitfury.json
@@ -10,7 +10,5 @@
     "/BitFury/",
     "/Bitfury/"
   ],
-  "links": [
-    "https://bitfury.com"
-  ]
+  "link": "https://bitfury.com"
 }

--- a/pools/bitminter.json
+++ b/pools/bitminter.json
@@ -6,7 +6,5 @@
   "tags": [
     "BitMinter"
   ],
-  "links": [
-    "https://bitminter.com"
-  ]
+  "link": "https://bitminter.com"
 }

--- a/pools/bitparking.json
+++ b/pools/bitparking.json
@@ -4,7 +4,5 @@
   "tags": [
     "bitparking"
   ],
-  "links": [
-    "https://mmpool.bitparking.com"
-  ]
+  "link": "https://mmpool.bitparking.com"
 }

--- a/pools/bitsolo.json
+++ b/pools/bitsolo.json
@@ -6,7 +6,5 @@
   "tags": [
     "Bitsolo Pool"
   ],
-  "links": [
-    "https://bitsolo.net"
-  ]
+  "link": "https://bitsolo.net"
 }

--- a/pools/bixin.json
+++ b/pools/bixin.json
@@ -9,7 +9,5 @@
     "/HaoBTC/",
     "HAOBTC"
   ],
-  "links": [
-    "https://haopool.com"
-  ]
+  "link": "https://haopool.com"
 }

--- a/pools/blockfills.json
+++ b/pools/blockfills.json
@@ -6,7 +6,5 @@
   "tags": [
     "BlockfillsPool"
   ],
-  "links": [
-    "https://www.blockfills.com/mining"
-  ]
+  "link": "https://www.blockfills.com/mining"
 }

--- a/pools/bravo-mining.json
+++ b/pools/bravo-mining.json
@@ -4,7 +4,5 @@
   "tags": [
     "/bravo-mining/"
   ],
-  "links": [
-    "https://www.bravo-mining.com"
-  ]
+  "link": "https://www.bravo-mining.com"
 }

--- a/pools/btc-com.json
+++ b/pools/btc-com.json
@@ -13,7 +13,5 @@
     "/BTC.com/",
     "btccom"
   ],
-  "links": [
-    "https://pool.btc.com"
-  ]
+  "link": "https://pool.btc.com"
 }

--- a/pools/btc-guild.json
+++ b/pools/btc-guild.json
@@ -4,7 +4,5 @@
   "tags": [
     "BTC Guild"
   ],
-  "links": [
-    "https://www.btcguild.com"
-  ]
+  "link": "https://www.btcguild.com"
 }

--- a/pools/btc-nuggets.json
+++ b/pools/btc-nuggets.json
@@ -4,7 +4,5 @@
     "1BwZeHJo7b7M2op7VDfYnsmcpXsUYEcVHm"
   ],
   "tags": [],
-  "links": [
-    "https://104.197.8.250"
-  ]
+  "link": "https://104.197.8.250"
 }

--- a/pools/btc-top.json
+++ b/pools/btc-top.json
@@ -6,8 +6,5 @@
   "tags": [
     "/BTC.TOP/"
   ],
-  "links": [
-    "https://btc.top",
-    "https://www.btc.top"
-  ]
+  "link": "https://btc.top"
 }

--- a/pools/btcc.json
+++ b/pools/btcc.json
@@ -9,7 +9,5 @@
     "BTCChina.com",
     "btcchina.com"
   ],
-  "links": [
-    "https://pool.btcc.com"
-  ]
+  "link": "https://pool.btcc.com"
 }

--- a/pools/btcdig.json
+++ b/pools/btcdig.json
@@ -4,7 +4,5 @@
     "15MxzsutVroEE9XiDckLxUHTCDAEZgPZJi"
   ],
   "tags": [],
-  "links": [
-    "https://btcdig.com"
-  ]
+  "link": "https://btcdig.com"
 }

--- a/pools/btcmp.json
+++ b/pools/btcmp.json
@@ -4,7 +4,5 @@
     "1jKSjMLnDNup6NPgCjveeP9tUn4YpT94Y"
   ],
   "tags": [],
-  "links": [
-    "https://www.btcmp.com"
-  ]
+  "link": "https://www.btcmp.com"
 }

--- a/pools/btcpool-unidentified.json
+++ b/pools/btcpool-unidentified.json
@@ -4,7 +4,5 @@
   "tags": [
     "BTCPool"
   ],
-  "links": [
-    "https://github.com/0xB10C/known-mining-pools/issues/28"
-  ]
+  "link": "https://github.com/0xB10C/known-mining-pools/issues/28"
 }

--- a/pools/btcpool.json
+++ b/pools/btcpool.json
@@ -4,5 +4,5 @@
     "1Ca1KNQQo8akbrwTjjXuk8aikvC2pwodU2"
   ],
   "tags": [],
-  "links": []
+  "link": ""
 }

--- a/pools/btcserv.json
+++ b/pools/btcserv.json
@@ -4,7 +4,5 @@
   "tags": [
     "btcserv"
   ],
-  "links": [
-    "https://btcserv.net"
-  ]
+  "link": "https://btcserv.net"
 }

--- a/pools/btpool.json
+++ b/pools/btpool.json
@@ -4,5 +4,5 @@
   "tags": [
     "/BTPOOL/"
   ],
-  "links": []
+  "link": ""
 }

--- a/pools/bwpool.json
+++ b/pools/bwpool.json
@@ -7,7 +7,5 @@
     "BW Pool",
     "BWPool"
   ],
-  "links": [
-    "https://bwpool.net"
-  ]
+  "link": "https://bwpool.net"
 }

--- a/pools/bytepool.json
+++ b/pools/bytepool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/bytepool.com/"
   ],
-  "links": [
-    "https://www.bytepool.com"
-  ]
+  "link": "https://www.bytepool.com"
 }

--- a/pools/canoe.json
+++ b/pools/canoe.json
@@ -4,7 +4,5 @@
     "1Afcpc2FpPnREU6i52K3cicmHdvYRAH9Wo"
   ],
   "tags": [],
-  "links": [
-    "https://www.canoepool.com"
-  ]
+  "link": "https://www.canoepool.com"
 }

--- a/pools/canoepool.json
+++ b/pools/canoepool.json
@@ -7,8 +7,5 @@
     "/CANOE/",
     "/canoepool/"
   ],
-  "links": [
-    "https://btc.canoepool.com",
-    "https://www.canoepool.com"
-  ]
+  "link": "https://canoepool.com"
 }

--- a/pools/carbon-negative-unidentified.json
+++ b/pools/carbon-negative-unidentified.json
@@ -4,7 +4,5 @@
     "33SAB6pzbhEGPbfY6NVgRDV7jVfspZ3A3Z"
   ],
   "tags": [],
-  "links": [
-    "https://github.com/0xB10C/known-mining-pools/issues/48"
-  ]
+  "link": "https://github.com/0xB10C/known-mining-pools/issues/48"
 }

--- a/pools/ckpool.json
+++ b/pools/ckpool.json
@@ -1,16 +1,14 @@
 {
   "name": "CKPool",
   "addresses": [
-    "3P8sR3K8wAk3bom7tqpr5VrzCz9TVYNTQd",
     "1ApE99VM5RJzMRRtwd2JMgmkGabtJqoMEz",
+    "1EowSPumj9D9AMTpE64Jr7vT3PJDNopVcz",
     "1KGbsDDAgJN2HDNBjmMHp9828qATo5B9c9",
-    "1EowSPumj9D9AMTpE64Jr7vT3PJDNopVcz"
+    "3P8sR3K8wAk3bom7tqpr5VrzCz9TVYNTQd"
   ],
   "tags": [
     "/ckpool.org/",
     "ckpool"
   ],
-  "links": [
-    "https://ckpool.org"
-  ]
+  "link": "https://ckpool.org"
 }

--- a/pools/cloudhashing.json
+++ b/pools/cloudhashing.json
@@ -4,7 +4,5 @@
     "1ALA5v7h49QT7WYLcRsxcXqXUqEqaWmkvw"
   ],
   "tags": [],
-  "links": [
-    "https://cloudhashing.com"
-  ]
+  "link": "https://cloudhashing.com"
 }

--- a/pools/cntt.json
+++ b/pools/cntt.json
@@ -4,5 +4,5 @@
     "3QLeXx1J9Tp3TBnQyHrhVxne9KqkAS9JSR"
   ],
   "tags": [],
-  "links": []
+  "link": ""
 }

--- a/pools/coinlab.json
+++ b/pools/coinlab.json
@@ -4,7 +4,5 @@
   "tags": [
     "CoinLab"
   ],
-  "links": [
-    "https://coinlab.com"
-  ]
+  "link": "https://coinlab.com"
 }

--- a/pools/cointerra.json
+++ b/pools/cointerra.json
@@ -6,7 +6,5 @@
   "tags": [
     "cointerra"
   ],
-  "links": [
-    "https://cointerra.com"
-  ]
+  "link": "https://cointerra.com"
 }

--- a/pools/connectbtc.json
+++ b/pools/connectbtc.json
@@ -6,7 +6,5 @@
   "tags": [
     "/ConnectBTC - Home for Miners/"
   ],
-  "links": [
-    "https://www.connectbtc.com"
-  ]
+  "link": "https://www.connectbtc.com"
 }

--- a/pools/dcex.json
+++ b/pools/dcex.json
@@ -4,7 +4,5 @@
   "tags": [
     "/DCEX/"
   ],
-  "links": [
-    "https://dcexploration.cn"
-  ]
+  "link": "https://dcexploration.cn"
 }

--- a/pools/dcexploration.json
+++ b/pools/dcexploration.json
@@ -4,7 +4,5 @@
   "tags": [
     "/DCExploration/"
   ],
-  "links": [
-    "https://dcexploration.cn"
-  ]
+  "link": "https://dcexploration.cn"
 }

--- a/pools/digitalbtc.json
+++ b/pools/digitalbtc.json
@@ -6,7 +6,5 @@
   "tags": [
     "/agentD/"
   ],
-  "links": [
-    "https://digitalbtc.com"
-  ]
+  "link": "https://digitalbtc.com"
 }

--- a/pools/digitalx-mintsy.json
+++ b/pools/digitalx-mintsy.json
@@ -4,7 +4,5 @@
     "1NY15MK947MLzmPUa2gL7UgyR8prLh2xfu"
   ],
   "tags": [],
-  "links": [
-    "https://www.mintsy.co"
-  ]
+  "link": "https://www.mintsy.co"
 }

--- a/pools/dpool.json
+++ b/pools/dpool.json
@@ -7,7 +7,5 @@
   "tags": [
     "/DPOOL.TOP/"
   ],
-  "links": [
-    "https://www.dpool.top"
-  ]
+  "link": "https://www.dpool.top"
 }

--- a/pools/eclipsemc.json
+++ b/pools/eclipsemc.json
@@ -7,7 +7,5 @@
   "tags": [
     "EMC"
   ],
-  "links": [
-    "https://eclipsemc.com"
-  ]
+  "link": "https://eclipsemc.com"
 }

--- a/pools/ekanembtc.json
+++ b/pools/ekanembtc.json
@@ -4,7 +4,5 @@
     "1Cs5RT9SRk1hxsdzivAfkjesNmVVJqfqkw"
   ],
   "tags": [],
-  "links": [
-    "https://ekanembtc.com"
-  ]
+  "link": "https://ekanembtc.com"
 }

--- a/pools/eligius.json
+++ b/pools/eligius.json
@@ -4,7 +4,5 @@
   "tags": [
     "Eligius"
   ],
-  "links": [
-    "https://eligius.st"
-  ]
+  "link": "https://eligius.st"
 }

--- a/pools/emcdpool.json
+++ b/pools/emcdpool.json
@@ -8,7 +8,5 @@
     "/one_more_mcd/",
     "get___emcd"
   ],
-  "links": [
-    "https://pool.emcd.io"
-  ]
+  "link": "https://pool.emcd.io"
 }

--- a/pools/eobot.json
+++ b/pools/eobot.json
@@ -5,7 +5,5 @@
     "1MPxhNkSzeTNTHSZAibMaS8HS1esmUL1ne"
   ],
   "tags": [],
-  "links": [
-    "https://eobot.com"
-  ]
+  "link": "https://eobot.com"
 }

--- a/pools/exxbw.json
+++ b/pools/exxbw.json
@@ -4,7 +4,5 @@
   "tags": [
     "xbtc.exx.com&bw.com"
   ],
-  "links": [
-    "https://xbtc.exx.com"
-  ]
+  "link": "https://xbtc.exx.com"
 }

--- a/pools/f2pool.json
+++ b/pools/f2pool.json
@@ -9,7 +9,5 @@
     "七彩神仙鱼",
     "🐟"
   ],
-  "links": [
-    "https://www.f2pool.com"
-  ]
+  "link": "https://www.f2pool.com"
 }

--- a/pools/foundry-usa.json
+++ b/pools/foundry-usa.json
@@ -8,7 +8,5 @@
     "/2cDw/",
     "Foundry USA Pool"
   ],
-  "links": [
-    "https://foundrydigital.com"
-  ]
+  "link": "https://foundrydigital.com"
 }

--- a/pools/gbminers.json
+++ b/pools/gbminers.json
@@ -4,7 +4,5 @@
   "tags": [
     "/mined by gbminers/"
   ],
-  "links": [
-    "https://gbminers.com"
-  ]
+  "link": "https://gbminers.com"
 }

--- a/pools/ghash-io.json
+++ b/pools/ghash-io.json
@@ -6,7 +6,5 @@
   "tags": [
     "ghash.io"
   ],
-  "links": [
-    "https://ghash.io"
-  ]
+  "link": "https://ghash.io"
 }

--- a/pools/give-me-coins.json
+++ b/pools/give-me-coins.json
@@ -4,7 +4,5 @@
   "tags": [
     "Give-Me-Coins"
   ],
-  "links": [
-    "https://give-me-coins.com"
-  ]
+  "link": "https://give-me-coins.com"
 }

--- a/pools/gogreenlight.json
+++ b/pools/gogreenlight.json
@@ -4,7 +4,5 @@
     "18EPLvrs2UE11kWBB3ABS7Crwj5tTBYPoa"
   ],
   "tags": [],
-  "links": [
-    "https://www.gogreenlight.se"
-  ]
+  "link": "https://www.gogreenlight.se"
 }

--- a/pools/haominer.json
+++ b/pools/haominer.json
@@ -4,7 +4,5 @@
   "tags": [
     "/haominer/"
   ],
-  "links": [
-    "https://haominer.com"
-  ]
+  "link": "https://haominer.com"
 }

--- a/pools/haozhuzhu.json
+++ b/pools/haozhuzhu.json
@@ -6,7 +6,5 @@
   "tags": [
     "/haozhuzhu/"
   ],
-  "links": [
-    "https://haozhuzhu.com"
-  ]
+  "link": "https://haozhuzhu.com"
 }

--- a/pools/hashbx.json
+++ b/pools/hashbx.json
@@ -4,7 +4,5 @@
   "tags": [
     "/Mined by HashBX.io/"
   ],
-  "links": [
-    "https://hashbx.io"
-  ]
+  "link": "https://hashbx.io"
 }

--- a/pools/hashpool.json
+++ b/pools/hashpool.json
@@ -4,7 +4,5 @@
   "tags": [
     "HASHPOOL"
   ],
-  "links": [
-    "https://hashpool.com"
-  ]
+  "link": "https://hashpool.com"
 }

--- a/pools/helix.json
+++ b/pools/helix.json
@@ -4,5 +4,5 @@
   "tags": [
     "/Helix/"
   ],
-  "links": []
+  "link": ""
 }

--- a/pools/hhtt.json
+++ b/pools/hhtt.json
@@ -4,7 +4,5 @@
   "tags": [
     "HHTT"
   ],
-  "links": [
-    "https://hhtt.1209k.com"
-  ]
+  "link": "https://hhtt.1209k.com"
 }

--- a/pools/hotpool.json
+++ b/pools/hotpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/HotPool/"
   ],
-  "links": [
-    "https://hotpool.co"
-  ]
+  "link": "https://hotpool.co"
 }

--- a/pools/hummerpool.json
+++ b/pools/hummerpool.json
@@ -5,7 +5,5 @@
     "HummerPool",
     "Hummerpool"
   ],
-  "links": [
-    "https://www.hummerpool.com"
-  ]
+  "link": "https://www.hummerpool.com"
 }

--- a/pools/huobi-pool.json
+++ b/pools/huobi-pool.json
@@ -10,7 +10,5 @@
     "/HuoBi/",
     "/Huobi/"
   ],
-  "links": [
-    "https://www.hpt.com"
-  ]
+  "link": "https://www.hpt.com"
 }

--- a/pools/kanopool.json
+++ b/pools/kanopool.json
@@ -4,7 +4,5 @@
   "tags": [
     "Kano"
   ],
-  "links": [
-    "https://kano.is"
-  ]
+  "link": "https://kano.is"
 }

--- a/pools/kncminer.json
+++ b/pools/kncminer.json
@@ -4,7 +4,5 @@
   "tags": [
     "KnCMiner"
   ],
-  "links": [
-    "https://portal.kncminer.com/pool"
-  ]
+  "link": "https://portal.kncminer.com/pool"
 }

--- a/pools/kucoin-pool.json
+++ b/pools/kucoin-pool.json
@@ -6,7 +6,5 @@
   "tags": [
     "KuCoinPool"
   ],
-  "links": [
-    "https://www.kucoin.com/mining-pool"
-  ]
+  "link": "https://www.kucoin.com/mining-pool"
 }

--- a/pools/lubian-com.json
+++ b/pools/lubian-com.json
@@ -7,7 +7,5 @@
     "/Buffett/",
     "/lubian.com/"
   ],
-  "links": [
-    "https://www.lubian.com"
-  ]
+  "link": "https://www.lubian.com"
 }

--- a/pools/luxor.json
+++ b/pools/luxor.json
@@ -6,7 +6,5 @@
   "tags": [
     "/LUXOR/"
   ],
-  "links": [
-    "https://mining.luxor.tech"
-  ]
+  "link": "https://mining.luxor.tech"
 }

--- a/pools/mara-pool.json
+++ b/pools/mara-pool.json
@@ -9,7 +9,5 @@
   "tags": [
     "MARA Pool"
   ],
-  "links": [
-    "https://marathondh.com"
-  ]
+  "link": "https://marathondh.com"
 }

--- a/pools/maxbtc.json
+++ b/pools/maxbtc.json
@@ -4,7 +4,5 @@
   "tags": [
     "MaxBTC"
   ],
-  "links": [
-    "https://maxbtc.com"
-  ]
+  "link": "https://maxbtc.com"
 }

--- a/pools/megabigpower.json
+++ b/pools/megabigpower.json
@@ -9,7 +9,5 @@
   "tags": [
     "megabigpower.com"
   ],
-  "links": [
-    "https://megabigpower.com"
-  ]
+  "link": "https://megabigpower.com"
 }

--- a/pools/minerium.json
+++ b/pools/minerium.json
@@ -4,7 +4,5 @@
   "tags": [
     "/Minerium.com/"
   ],
-  "links": [
-    "https://www.minerium.com"
-  ]
+  "link": "https://www.minerium.com"
 }

--- a/pools/miningcity.json
+++ b/pools/miningcity.json
@@ -6,7 +6,5 @@
   "tags": [
     "MiningCity"
   ],
-  "links": [
-    "https://www.miningcity.com"
-  ]
+  "link": "https://www.miningcity.com"
 }

--- a/pools/mmpool.json
+++ b/pools/mmpool.json
@@ -4,7 +4,5 @@
   "tags": [
     "mmpool"
   ],
-  "links": [
-    "https://mmpool.org/pool"
-  ]
+  "link": "https://mmpool.org/pool"
 }

--- a/pools/mt-red.json
+++ b/pools/mt-red.json
@@ -4,7 +4,5 @@
   "tags": [
     "/mtred/"
   ],
-  "links": [
-    "https://mtred.com"
-  ]
+  "link": "https://mtred.com"
 }

--- a/pools/multicoin-co.json
+++ b/pools/multicoin-co.json
@@ -4,7 +4,5 @@
   "tags": [
     "Mined by MultiCoin.co"
   ],
-  "links": [
-    "https://multicoin.co"
-  ]
+  "link": "https://multicoin.co"
 }

--- a/pools/multipool.json
+++ b/pools/multipool.json
@@ -4,7 +4,5 @@
     "1MeffGLauEj2CZ18hRQqUauTXb9JAuLbGw"
   ],
   "tags": [],
-  "links": [
-    "https://www.multipool.us"
-  ]
+  "link": "https://www.multipool.us"
 }

--- a/pools/mybtccoin-pool.json
+++ b/pools/mybtccoin-pool.json
@@ -6,8 +6,5 @@
   "tags": [
     "myBTCcoin Pool"
   ],
-  "links": [
-    "https://mybtccoin.com",
-    "https://www.mybtccoin.com"
-  ]
+  "link": "https://mybtccoin.com"
 }

--- a/pools/nexious.json
+++ b/pools/nexious.json
@@ -6,7 +6,5 @@
   "tags": [
     "/Nexious/"
   ],
-  "links": [
-    "https://nexious.com"
-  ]
+  "link": "https://nexious.com"
 }

--- a/pools/nicehash.json
+++ b/pools/nicehash.json
@@ -4,7 +4,5 @@
   "tags": [
     "/NiceHashSolo"
   ],
-  "links": [
-    "https://solo.nicehash.com"
-  ]
+  "link": "https://solo.nicehash.com"
 }

--- a/pools/nmcbit.json
+++ b/pools/nmcbit.json
@@ -4,7 +4,5 @@
   "tags": [
     "nmcbit.com"
   ],
-  "links": [
-    "https://nmcbit.com"
-  ]
+  "link": "https://nmcbit.com"
 }

--- a/pools/novablock.json
+++ b/pools/novablock.json
@@ -6,7 +6,5 @@
   "tags": [
     "/NovaBlock/"
   ],
-  "links": [
-    "https://novablock.com"
-  ]
+  "link": "https://novablock.com"
 }

--- a/pools/okexpool.json
+++ b/pools/okexpool.json
@@ -4,7 +4,5 @@
   "tags": [
     "/www.okex.com/"
   ],
-  "links": [
-    "https://www.okex.com"
-  ]
+  "link": "https://www.okex.com"
 }

--- a/pools/okkong.json
+++ b/pools/okkong.json
@@ -6,7 +6,5 @@
   "tags": [
     "/hash.okkong.com/"
   ],
-  "links": [
-    "https://hash.okkong.com"
-  ]
+  "link": "https://hash.okkong.com"
 }

--- a/pools/okminer.json
+++ b/pools/okminer.json
@@ -6,7 +6,5 @@
   "tags": [
     "okminer.com/euz"
   ],
-  "links": [
-    "https://okminer.com"
-  ]
+  "link": "https://okminer.com"
 }

--- a/pools/okpool-top.json
+++ b/pools/okpool-top.json
@@ -4,7 +4,5 @@
   "tags": [
     "/www.okpool.top/"
   ],
-  "links": [
-    "https://www.okpool.top"
-  ]
+  "link": "https://www.okpool.top"
 }

--- a/pools/ozcoin.json
+++ b/pools/ozcoin.json
@@ -5,7 +5,5 @@
     "ozco.in",
     "ozcoin"
   ],
-  "links": [
-    "https://ozcoin.net"
-  ]
+  "link": "https://ozcoin.net"
 }

--- a/pools/patels.json
+++ b/pools/patels.json
@@ -5,7 +5,5 @@
     "19RE4mz2UbDxDVougc6GGdoT4x5yXxwFq2"
   ],
   "tags": [],
-  "links": [
-    "https://patelsminingpool.com"
-  ]
+  "link": "https://patelsminingpool.com"
 }

--- a/pools/pega-pool.json
+++ b/pools/pega-pool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/pegapool/"
   ],
-  "links": [
-    "https://www.pega-pool.com"
-  ]
+  "link": "https://www.pega-pool.com"
 }

--- a/pools/phash-io.json
+++ b/pools/phash-io.json
@@ -5,7 +5,5 @@
     "/phash.cn/",
     "/phash.io/"
   ],
-  "links": [
-    "https://phash.io"
-  ]
+  "link": "https://phash.io"
 }

--- a/pools/polmine.json
+++ b/pools/polmine.json
@@ -13,7 +13,5 @@
     "by polmine.pl",
     "bypmneU"
   ],
-  "links": [
-    "https://polmine.pl"
-  ]
+  "link": "https://polmine.pl"
 }

--- a/pools/poolin.json
+++ b/pools/poolin.json
@@ -19,7 +19,5 @@
     "/poolin",
     "/poolin.com"
   ],
-  "links": [
-    "https://www.poolin.com"
-  ]
+  "link": "https://www.poolin.com"
 }

--- a/pools/rawpool.json
+++ b/pools/rawpool.json
@@ -8,7 +8,5 @@
   "tags": [
     "/Rawpool.com/"
   ],
-  "links": [
-    "https://www.rawpool.com"
-  ]
+  "link": "https://www.rawpool.com"
 }

--- a/pools/rigpool.json
+++ b/pools/rigpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/RigPool.com/"
   ],
-  "links": [
-    "https://www.rigpool.com"
-  ]
+  "link": "https://www.rigpool.com"
 }

--- a/pools/sbi-crypto.json
+++ b/pools/sbi-crypto.json
@@ -6,8 +6,5 @@
     "SBI Crypto",
     "SBICrypto"
   ],
-  "links": [
-    "https://sbicrypto.com",
-    "https://www.sbicrypto.com"
-  ]
+  "link": "https://sbicrypto.com"
 }

--- a/pools/secretsuperstar.json
+++ b/pools/secretsuperstar.json
@@ -4,5 +4,5 @@
   "tags": [
     "/SecretSuperstar/"
   ],
-  "links": []
+  "link": ""
 }

--- a/pools/shawnp0wers.json
+++ b/pools/shawnp0wers.json
@@ -7,7 +7,5 @@
   "tags": [
     "--Nug--"
   ],
-  "links": [
-    "https://www.brainofshawn.com"
-  ]
+  "link": "https://www.brainofshawn.com"
 }

--- a/pools/sigmapool-com.json
+++ b/pools/sigmapool-com.json
@@ -6,7 +6,5 @@
   "tags": [
     "/Sigmapool.com/"
   ],
-  "links": [
-    "https://sigmapool.com"
-  ]
+  "link": "https://sigmapool.com"
 }

--- a/pools/simplecoin-us.json
+++ b/pools/simplecoin-us.json
@@ -4,7 +4,5 @@
   "tags": [
     "simplecoin"
   ],
-  "links": [
-    "https://simplecoin.us"
-  ]
+  "link": "https://simplecoin.us"
 }

--- a/pools/slushpool.json
+++ b/pools/slushpool.json
@@ -7,7 +7,5 @@
   "tags": [
     "/slush/"
   ],
-  "links": [
-    "https://slushpool.com"
-  ]
+  "link": "https://slushpool.com"
 }

--- a/pools/solo-ck.json
+++ b/pools/solo-ck.json
@@ -4,7 +4,5 @@
   "tags": [
     "/solo.ckpool.org/"
   ],
-  "links": [
-    "https://solo.ckpool.org"
-  ]
+  "link": "https://solo.ckpool.org"
 }

--- a/pools/spiderpool.json
+++ b/pools/spiderpool.json
@@ -7,7 +7,5 @@
   "tags": [
     "/SpiderPool/"
   ],
-  "links": [
-    "https://www.spiderpool.com"
-  ]
+  "link": "https://www.spiderpool.com"
 }

--- a/pools/st-mining-corp.json
+++ b/pools/st-mining-corp.json
@@ -4,7 +4,5 @@
   "tags": [
     "st mining corp"
   ],
-  "links": [
-    "https://bitcointalk.org/index.php?topic=77000.msg3207708#msg3207708"
-  ]
+  "link": "https://bitcointalk.org/index.php?topic=77000.msg3207708#msg3207708"
 }

--- a/pools/tangpool.json
+++ b/pools/tangpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "/Tangpool/"
   ],
-  "links": [
-    "https://www.tangpool.com"
-  ]
+  "link": "https://www.tangpool.com"
 }

--- a/pools/tatmas-pool.json
+++ b/pools/tatmas-pool.json
@@ -4,7 +4,5 @@
   "tags": [
     "/ViaBTC/TATMAS Pool/"
   ],
-  "links": [
-    "https://tmsminer.com"
-  ]
+  "link": "https://tmsminer.com"
 }

--- a/pools/tbdice.json
+++ b/pools/tbdice.json
@@ -4,7 +4,5 @@
   "tags": [
     "TBDice"
   ],
-  "links": [
-    "https://tbdice.org"
-  ]
+  "link": "https://tbdice.org"
 }

--- a/pools/telco-214.json
+++ b/pools/telco-214.json
@@ -14,7 +14,5 @@
     "1P4B6rx1js8TaEDXvZvtrkiEb9XrJgMQ19"
   ],
   "tags": [],
-  "links": [
-    "https://www.telco214.com"
-  ]
+  "link": "https://www.telco214.com"
 }

--- a/pools/terra-pool.json
+++ b/pools/terra-pool.json
@@ -7,7 +7,5 @@
   "tags": [
     "terrapool.io"
   ],
-  "links": [
-    "https://terrapool.io"
-  ]
+  "link": "https://terrapool.io"
 }

--- a/pools/tiger.json
+++ b/pools/tiger.json
@@ -4,5 +4,5 @@
     "1LsFmhnne74EmU4q4aobfxfrWY4wfMVd8w"
   ],
   "tags": [],
-  "links": []
+  "link": ""
 }

--- a/pools/tigerpool-net.json
+++ b/pools/tigerpool-net.json
@@ -4,5 +4,5 @@
   "tags": [
     "/tigerpool.net"
   ],
-  "links": []
+  "link": ""
 }

--- a/pools/titan.json
+++ b/pools/titan.json
@@ -6,7 +6,5 @@
   "tags": [
     "Titan.io"
   ],
-  "links": [
-    "https://titan.io"
-  ]
+  "link": "https://titan.io"
 }

--- a/pools/tmspool.json
+++ b/pools/tmspool.json
@@ -4,7 +4,5 @@
   "tags": [
     "/TMSPOOL/"
   ],
-  "links": [
-    "https://btc.tmspool.top"
-  ]
+  "link": "https://btc.tmspool.top"
 }

--- a/pools/togetherpool.json
+++ b/pools/togetherpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "TogetherPool"
   ],
-  "links": [
-    "https://www.togetherpool.com"
-  ]
+  "link": "https://www.togetherpool.com"
 }

--- a/pools/transactioncoinmining.json
+++ b/pools/transactioncoinmining.json
@@ -4,7 +4,5 @@
     "1qtKetXKgqa7j1KrB19HbvfRiNUncmakk"
   ],
   "tags": [],
-  "links": [
-    "https://sha256.transactioncoinmining.com"
-  ]
+  "link": "https://sha256.transactioncoinmining.com"
 }

--- a/pools/trickys-btc-pool.json
+++ b/pools/trickys-btc-pool.json
@@ -4,7 +4,5 @@
     "1AePMyovoijxvHuKhTqWvpaAkRCF4QswC6"
   ],
   "tags": [],
-  "links": [
-    "https://pool.wemine.uk"
-  ]
+  "link": "https://pool.wemine.uk"
 }

--- a/pools/triplemining.json
+++ b/pools/triplemining.json
@@ -5,7 +5,5 @@
     "Triplemining.com",
     "triplemining"
   ],
-  "links": [
-    "https://www.triplemining.com"
-  ]
+  "link": "https://www.triplemining.com"
 }

--- a/pools/ukrpool.json
+++ b/pools/ukrpool.json
@@ -6,7 +6,5 @@
   "tags": [
     "Ukrpool.com"
   ],
-  "links": [
-    "https://ukrpool.com"
-  ]
+  "link": "https://ukrpool.com"
 }

--- a/pools/ultimus-pool.json
+++ b/pools/ultimus-pool.json
@@ -7,7 +7,5 @@
   "tags": [
     "/ultimus/"
   ],
-  "links": [
-    "https://www.ultimuspool.com"
-  ]
+  "link": "https://www.ultimuspool.com"
 }

--- a/pools/unomp.json
+++ b/pools/unomp.json
@@ -4,7 +4,5 @@
     "1BRY8AD7vSNUEE75NjzfgiG18mWjGQSRuJ"
   ],
   "tags": [],
-  "links": [
-    "https://199.115.116.7:8925"
-  ]
+  "link": "https://199.115.116.7:8925"
 }

--- a/pools/viabtc.json
+++ b/pools/viabtc.json
@@ -5,7 +5,5 @@
     "/ViaBTC/",
     "viabtc.com deploy"
   ],
-  "links": [
-    "https://viabtc.com"
-  ]
+  "link": "https://viabtc.com"
 }

--- a/pools/waterhole.json
+++ b/pools/waterhole.json
@@ -6,7 +6,5 @@
   "tags": [
     "/WATERHOLE.IO/"
   ],
-  "links": [
-    "https://btc.waterhole.io"
-  ]
+  "link": "https://btc.waterhole.io"
 }

--- a/pools/wayi-cn.json
+++ b/pools/wayi-cn.json
@@ -5,7 +5,5 @@
     "/E2M & BTC.TOP/",
     "/E2M/"
   ],
-  "links": [
-    "https://www.easy2mine.com"
-  ]
+  "link": "https://www.easy2mine.com"
 }

--- a/pools/yourbtc-net.json
+++ b/pools/yourbtc-net.json
@@ -4,7 +4,5 @@
   "tags": [
     "yourbtc.net"
   ],
-  "links": [
-    "https://yourbtc.net"
-  ]
+  "link": "https://yourbtc.net"
 }


### PR DESCRIPTION
We don't need multiple links per pool. This just makes it harder to generate dataset for downstream tools.

I've used this python script for this patch:

```python3
#!/usr/bin/env python3

import json
import glob
import sys

entity_files = glob.glob("pools/*.json")

addresses = dict()
tags = dict()

for file_path in entity_files:
    with open(file_path, "r") as f:
        e = json.load(f)

        link = ""

        if len(e["links"]) == 0:
            print(f"No links for pool {e['name']}")
        elif len(e["links"]) == 1:
            link = e["links"][0]
        elif len(e["links"]) > 1:
            link = e["links"][0]
            print(f"Using {link} for pool {e['name']} out of", e["links"])

        content = {
            "name": e["name"],
            "addresses": sorted(e["addresses"]),
            "tags": sorted(e["tags"]),
            "link": link,
        }

        with open(file_path, "w") as out:
            json.dump(content, out, indent=2, ensure_ascii=False)
            out.write('\n')
```

It did output:

```
No links for pool tigerpool.net
No links for pool Helix
Using https://mybtccoin.com for pool myBTCcoin Pool out of ['https://mybtccoin.com', 'https://www.mybtccoin.com']
Using https://btc.top for pool BTC.TOP out of ['https://btc.top', 'https://www.btc.top']
No links for pool tiger
No links for pool SecretSuperstar
No links for pool ArkPool
Using https://www.bitarms.io for pool Bitfarms out of ['https://www.bitarms.io', 'https://www.bitfarms.io']
No links for pool BTCPool
Using https://sbicrypto.com for pool SBI Crypto out of ['https://sbicrypto.com', 'https://www.sbicrypto.com']
No links for pool BTPOOL
No links for pool CN/TT
Using https://btc.canoepool.com for pool CanoePool out of ['https://btc.canoepool.com', 'https://www.canoepool.com']
```

I've manually changed
- bitarms.io -> bitfarms.io
- btc.canoepool.com -> canoepool.com