### PR TITLE
cleanup: consolidate tigerpool

### DIFF
--- a/generated/pools.json
+++ b/generated/pools.json
@@ -505,7 +505,7 @@
       "link": "https://www.telco214.com"
     },
     "1LsFmhnne74EmU4q4aobfxfrWY4wfMVd8w": {
-      "name": "tiger",
+      "name": "Tiger Pool",
       "link": ""
     },
     "1M1Xw2rczxkF3p3wiNHaTmxvbpZZ7M6vaa": {
@@ -1034,10 +1034,6 @@
       "name": "Solo CK",
       "link": "https://solo.ckpool.org"
     },
-    "/tigerpool.net": {
-      "name": "tigerpool.net",
-      "link": ""
-    },
     "/ultimus/": {
       "name": "Ultimus Pool",
       "link": "https://www.ultimuspool.com"
@@ -1321,6 +1317,14 @@
     "terrapool.io": {
       "name": "Terra Pool",
       "link": "https://terrapool.io"
+    },
+    "tiger": {
+      "name": "Tiger Pool",
+      "link": ""
+    },
+    "tigerpool.net": {
+      "name": "Tiger Pool",
+      "link": ""
     },
     "triplemining": {
       "name": "TripleMining",

--- a/pools/tigerpool-net.json
+++ b/pools/tigerpool-net.json
@@ -1,8 +1,0 @@
-{
-  "name": "tigerpool.net",
-  "addresses": [],
-  "tags": [
-    "/tigerpool.net"
-  ],
-  "link": ""
-}

--- a/pools/tigerpool.json
+++ b/pools/tigerpool.json
@@ -1,8 +1,11 @@
 {
-  "name": "tiger",
+  "name": "Tiger Pool",
   "addresses": [
     "1LsFmhnne74EmU4q4aobfxfrWY4wfMVd8w"
   ],
-  "tags": [],
+  "tags": [
+    "tiger",
+    "tigerpool.net"
+  ],
   "link": ""
 }


### PR DESCRIPTION
Not adding "tigerpool.net" as link as this site isn't a mining pool.

Also adds 39pLhpmYEhYaz6MrxvBVndTEK1x45MAsdN as a Tiger Pool address.

Switch from 'tiger' to 'tiger/tigerpool.net' at some point in 07-2018:
- Last 'tiger' block: 2018-07-02 04:02 https://mempool.space/block/00000000000000000004b07bb4fe6f4dc224d78c91b52eb78826f1b04ce1fbd5
- First 'tiger/tigerpool.net' block: 2018-07-26 07:27 https://mempool.space/block/000000000000000000150389188939b867d93f03f9f6f6e293a47c625c189386