### PR TITLE
Use integers as pool IDs 

### DIFF
--- a/.github/workflows/pools-json-validator.yml
+++ b/.github/workflows/pools-json-validator.yml
@@ -23,4 +23,5 @@ jobs:
           INPUT_JSONS: pools.json
       - name: Check if pools.json is up-to-date (matches what's generated from entities/*.json)
         run: ./qa/check-pool-json-uptodate.sh
-
+      - name: Check if the pool data is valid.
+        run: python3 qa/check-data.py

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ folder. For each pool, the following information is included in the JSON file:
 
 ```JSON
 {
-  "id": "examplepool",
+  "id": 7,
   "name": "Example Pool",
   "addresses": [
     "15kDhRAcpgsugmh6mQsTcCHdvbsuYncEEV",

--- a/pools/175btc.json
+++ b/pools/175btc.json
@@ -1,5 +1,5 @@
 {
-  "id": "175btc",
+  "id": 34,
   "name": "175btc",
   "addresses": [],
   "tags": [

--- a/pools/1hash.json
+++ b/pools/1hash.json
@@ -1,5 +1,5 @@
 {
-  "id": "1hash",
+  "id": 62,
   "name": "1Hash",
   "addresses": [
     "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV"

--- a/pools/1thash.json
+++ b/pools/1thash.json
@@ -1,5 +1,5 @@
 {
-  "id": "1thash",
+  "id": 70,
   "name": "1THash",
   "addresses": [
     "147SwRQdpCfj5p8PnfsXV2SsVVpVcz3aPq",

--- a/pools/21-inc.json
+++ b/pools/21-inc.json
@@ -1,5 +1,5 @@
 {
-  "id": "21inc",
+  "id": 116,
   "name": "21 Inc.",
   "addresses": [
     "15rQXUSBQRubShPpiJfDLxmwS8ze2RUm4z",

--- a/pools/50btc.json
+++ b/pools/50btc.json
@@ -1,5 +1,5 @@
 {
-  "id": "50btc",
+  "id": 105,
   "name": "50BTC",
   "addresses": [],
   "tags": [

--- a/pools/58coin.json
+++ b/pools/58coin.json
@@ -1,5 +1,5 @@
 {
-  "id": "58coin",
+  "id": 120,
   "name": "58COIN",
   "addresses": [
     "199EDJoCpqV672qESEkfFgEqNT1iR2gj3t"

--- a/pools/7pool.json
+++ b/pools/7pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "7pool",
+  "id": 97,
   "name": "7pool",
   "addresses": [
     "1JLc3JxvpdL1g5zoX8sKLP4BkJQiwnJftU"

--- a/pools/8baochi.json
+++ b/pools/8baochi.json
@@ -1,5 +1,5 @@
 {
-  "id": "8baochi",
+  "id": 2,
   "name": "8baochi",
   "addresses": [
     "1Hk9gD8xMo2XBUhE73y5zXEM8xqgffTB5f"

--- a/pools/a-xbt.json
+++ b/pools/a-xbt.json
@@ -1,5 +1,5 @@
 {
-  "id": "axbt",
+  "id": 82,
   "name": "A-XBT",
   "addresses": [
     "1MFsp2txCPwMMBJjNNeKaduGGs8Wi1Ce7X"

--- a/pools/aao-pool.json
+++ b/pools/aao-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "aaopool",
+  "id": 127,
   "name": "AAO Pool",
   "addresses": [
     "12QVFmJH2b4455YUHkMpEnWLeRY3eJ4Jb5"

--- a/pools/antpool.json
+++ b/pools/antpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "antpool",
+  "id": 61,
   "name": "AntPool",
   "addresses": [
     "12dRugNcdxK39288NjcDV4GX7rMsKCGn6B",

--- a/pools/arkpool.json
+++ b/pools/arkpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "arkpool",
+  "id": 69,
   "name": "ArkPool",
   "addresses": [
     "1QEiAhdHdMhBgVbDM7zUXWGkNhgEEJ6uLd"

--- a/pools/asicminer.json
+++ b/pools/asicminer.json
@@ -1,5 +1,5 @@
 {
-  "id": "asicminer",
+  "id": 132,
   "name": "ASICMiner",
   "addresses": [],
   "tags": [

--- a/pools/batpool.json
+++ b/pools/batpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "batpool",
+  "id": 41,
   "name": "BATPOOL",
   "addresses": [
     "167ApWWxUSFQmz2jdz9xop3oAKdLejvMML"

--- a/pools/bcmonster.json
+++ b/pools/bcmonster.json
@@ -1,5 +1,5 @@
 {
-  "id": "bcmonster",
+  "id": 125,
   "name": "BCMonster",
   "addresses": [
     "1E18BNyobcoiejcDYAz5SjbrzifNDEpM88"

--- a/pools/bcpool-io.json
+++ b/pools/bcpool-io.json
@@ -1,5 +1,5 @@
 {
-  "id": "bcpoolio",
+  "id": 139,
   "name": "bcpool.io",
   "addresses": [],
   "tags": [

--- a/pools/binance-pool.json
+++ b/pools/binance-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "binancepool",
+  "id": 123,
   "name": "Binance Pool",
   "addresses": [
     "122pN8zvqTxJaA8fRY1PDBu4QYodqE5m2X",

--- a/pools/bitalo.json
+++ b/pools/bitalo.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitalo",
+  "id": 122,
   "name": "Bitalo",
   "addresses": [],
   "tags": [

--- a/pools/bitclub.json
+++ b/pools/bitclub.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitclub",
+  "id": 45,
   "name": "BitClub",
   "addresses": [
     "155fzsEBHy9Ri2bMQ8uuuR3tv1YzcDywd4"

--- a/pools/bitcoin-affiliate-network.json
+++ b/pools/bitcoin-affiliate-network.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoinaffiliatenetwork",
+  "id": 1,
   "name": "Bitcoin Affiliate Network",
   "addresses": [],
   "tags": [

--- a/pools/bitcoin-com.json
+++ b/pools/bitcoin-com.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoincom",
+  "id": 6,
   "name": "Bitcoin.com",
   "addresses": [],
   "tags": [

--- a/pools/bitcoin-india.json
+++ b/pools/bitcoin-india.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoinindia",
+  "id": 67,
   "name": "Bitcoin India",
   "addresses": [],
   "tags": [

--- a/pools/bitcoin-ukraine.json
+++ b/pools/bitcoin-ukraine.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoinukraine",
+  "id": 37,
   "name": "Bitcoin-Ukraine",
   "addresses": [],
   "tags": [

--- a/pools/bitcoinindia.json
+++ b/pools/bitcoinindia.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoinindia",
+  "id": 95,
   "name": "BitcoinIndia",
   "addresses": [
     "1AZ6BkCo4zgTuuLpRStJH8iNsehXTMp456"

--- a/pools/bitcoinrussia.json
+++ b/pools/bitcoinrussia.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitcoinrussia",
+  "id": 104,
   "name": "BitcoinRussia",
   "addresses": [
     "14R2r9FkyDmyxGB9xUVwVLdgsX9YfdVamk",

--- a/pools/bitdeer.json
+++ b/pools/bitdeer.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitdeer",
+  "id": 24,
   "name": "Bitdeer",
   "addresses": [],
   "tags": [

--- a/pools/bitfarms.json
+++ b/pools/bitfarms.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitfarms",
+  "id": 91,
   "name": "Bitfarms",
   "addresses": [
     "3GvEGtnvgeBJ3p3EpdZhvUkxY4pDARkbjd"

--- a/pools/bitfury.json
+++ b/pools/bitfury.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitfury",
+  "id": 54,
   "name": "BitFury",
   "addresses": [
     "14yfxkcpHnju97pecpM7fjuTkVdtbkcfE6",

--- a/pools/bitminter.json
+++ b/pools/bitminter.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitminter",
+  "id": 85,
   "name": "BitMinter",
   "addresses": [
     "19PkHafEN18mquJ9ChwZt5YEFoCdPP5vYB"

--- a/pools/bitparking.json
+++ b/pools/bitparking.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitparking",
+  "id": 79,
   "name": "Bitparking",
   "addresses": [],
   "tags": [

--- a/pools/bitsolo.json
+++ b/pools/bitsolo.json
@@ -1,5 +1,5 @@
 {
-  "id": "bitsolo",
+  "id": 133,
   "name": "Bitsolo",
   "addresses": [
     "18zRehBcA2YkYvsC7dfQiFJNyjmWvXsvon"

--- a/pools/bixin.json
+++ b/pools/bixin.json
@@ -1,5 +1,5 @@
 {
-  "id": "bixin",
+  "id": 128,
   "name": "Bixin",
   "addresses": [
     "13hQVEstgo4iPQZv9C7VELnLWF7UWtF4Q3",

--- a/pools/blockfills.json
+++ b/pools/blockfills.json
@@ -1,5 +1,5 @@
 {
-  "id": "blockfills",
+  "id": 117,
   "name": "BlockFills",
   "addresses": [
     "1PzVut5X6Nx7Mv4JHHKPtVM9Jr9LJ4Rbry"

--- a/pools/bravo-mining.json
+++ b/pools/bravo-mining.json
@@ -1,5 +1,5 @@
 {
-  "id": "bravomining",
+  "id": 35,
   "name": "Bravo Mining",
   "addresses": [],
   "tags": [

--- a/pools/btc-com.json
+++ b/pools/btc-com.json
@@ -1,5 +1,5 @@
 {
-  "id": "btccom",
+  "id": 43,
   "name": "BTC.com",
   "addresses": [
     "1Bf9sZvBHPFGVPX71WX2njhd1NXKv5y7v5",

--- a/pools/btc-guild.json
+++ b/pools/btc-guild.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcguild",
+  "id": 47,
   "name": "BTC Guild",
   "addresses": [],
   "tags": [

--- a/pools/btc-nuggets.json
+++ b/pools/btc-nuggets.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcnuggets",
+  "id": 65,
   "name": "BTC Nuggets",
   "addresses": [
     "1BwZeHJo7b7M2op7VDfYnsmcpXsUYEcVHm"

--- a/pools/btc-top.json
+++ b/pools/btc-top.json
@@ -1,5 +1,5 @@
 {
-  "id": "btctop",
+  "id": 49,
   "name": "BTC.TOP",
   "addresses": [
     "1Hz96kJKF2HLPGY15JWLB5m9qGNxvt8tHJ"

--- a/pools/btcc.json
+++ b/pools/btcc.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcc",
+  "id": 107,
   "name": "BTCC",
   "addresses": [
     "152f1muMCNa7goXYhYAQC61hxEgGacmncB"

--- a/pools/btcdig.json
+++ b/pools/btcdig.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcdig",
+  "id": 63,
   "name": "BTCDig",
   "addresses": [
     "15MxzsutVroEE9XiDckLxUHTCDAEZgPZJi"

--- a/pools/btcmp.json
+++ b/pools/btcmp.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcmp",
+  "id": 138,
   "name": "BTCMP",
   "addresses": [
     "1jKSjMLnDNup6NPgCjveeP9tUn4YpT94Y"

--- a/pools/btcpool.json
+++ b/pools/btcpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcpool",
+  "id": 101,
   "name": "BTCPool (unidentified)",
   "addresses": [
     "1Ca1KNQQo8akbrwTjjXuk8aikvC2pwodU2"

--- a/pools/btcserv.json
+++ b/pools/btcserv.json
@@ -1,5 +1,5 @@
 {
-  "id": "btcserv",
+  "id": 73,
   "name": "BTCServ",
   "addresses": [],
   "tags": [

--- a/pools/btpool.json
+++ b/pools/btpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "btpool",
+  "id": 109,
   "name": "BTPOOL",
   "addresses": [],
   "tags": [

--- a/pools/bwpool.json
+++ b/pools/bwpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "bwpool",
+  "id": 100,
   "name": "BWPool",
   "addresses": [
     "1JLRXD8rjRgQtTS9MvfQALfHgGWau9L9ky"

--- a/pools/bytepool.json
+++ b/pools/bytepool.json
@@ -1,5 +1,5 @@
 {
-  "id": "bytepool",
+  "id": 7,
   "name": "BytePool",
   "addresses": [
     "39m5Wvn9ZqyhYmCYpsyHuGMt5YYw4Vmh1Z"

--- a/pools/canoe.json
+++ b/pools/canoe.json
@@ -1,5 +1,5 @@
 {
-  "id": "canoe",
+  "id": 9,
   "name": "CANOE",
   "addresses": [
     "1Afcpc2FpPnREU6i52K3cicmHdvYRAH9Wo"

--- a/pools/canoepool.json
+++ b/pools/canoepool.json
@@ -1,5 +1,5 @@
 {
-  "id": "canoepool",
+  "id": 114,
   "name": "CanoePool",
   "addresses": [
     "1GP8eWArgpwRum76saJS4cZKCHWJHs9PQo"

--- a/pools/carbon-negative-unidentified.json
+++ b/pools/carbon-negative-unidentified.json
@@ -1,5 +1,5 @@
 {
-  "id": "carbonnegative",
+  "id": 13,
   "name": "Carbon Negative (unidentified)",
   "addresses": [
     "33SAB6pzbhEGPbfY6NVgRDV7jVfspZ3A3Z"

--- a/pools/ckpool.json
+++ b/pools/ckpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "ckpool",
+  "id": 75,
   "name": "CKPool",
   "addresses": [
     "1ApE99VM5RJzMRRtwd2JMgmkGabtJqoMEz",

--- a/pools/cloudhashing.json
+++ b/pools/cloudhashing.json
@@ -1,5 +1,5 @@
 {
-  "id": "cloudhashing",
+  "id": 135,
   "name": "CloudHashing",
   "addresses": [
     "1ALA5v7h49QT7WYLcRsxcXqXUqEqaWmkvw"

--- a/pools/cntt.json
+++ b/pools/cntt.json
@@ -1,5 +1,5 @@
 {
-  "id": "cntt",
+  "id": 112,
   "name": "CN/TT",
   "addresses": [
     "3QLeXx1J9Tp3TBnQyHrhVxne9KqkAS9JSR"

--- a/pools/coinlab.json
+++ b/pools/coinlab.json
@@ -1,5 +1,5 @@
 {
-  "id": "coinlab",
+  "id": 129,
   "name": "CoinLab",
   "addresses": [],
   "tags": [

--- a/pools/cointerra.json
+++ b/pools/cointerra.json
@@ -1,5 +1,5 @@
 {
-  "id": "cointerra",
+  "id": 19,
   "name": "Cointerra",
   "addresses": [
     "1BX5YoLwvqzvVwSrdD4dC32vbouHQn2tuF"

--- a/pools/connectbtc.json
+++ b/pools/connectbtc.json
@@ -1,5 +1,5 @@
 {
-  "id": "connectbtc",
+  "id": 90,
   "name": "ConnectBTC",
   "addresses": [
     "1KPQkehgYAqwiC6UCcbojM3mbGjURrQJF2"

--- a/pools/dcex.json
+++ b/pools/dcex.json
@@ -1,5 +1,5 @@
 {
-  "id": "dcex",
+  "id": 36,
   "name": "DCEX",
   "addresses": [],
   "tags": [

--- a/pools/dcexploration.json
+++ b/pools/dcexploration.json
@@ -1,5 +1,5 @@
 {
-  "id": "dcexploration",
+  "id": 64,
   "name": "DCExploration",
   "addresses": [],
   "tags": [

--- a/pools/digitalbtc.json
+++ b/pools/digitalbtc.json
@@ -1,5 +1,5 @@
 {
-  "id": "digitalbtc",
+  "id": 134,
   "name": "digitalBTC",
   "addresses": [
     "1MimPd6LrPKGftPRHWdfk8S3KYBfN4ELnD"

--- a/pools/digitalx-mintsy.json
+++ b/pools/digitalx-mintsy.json
@@ -1,5 +1,5 @@
 {
-  "id": "digitalxmintsy",
+  "id": 102,
   "name": "digitalX Mintsy",
   "addresses": [
     "1NY15MK947MLzmPUa2gL7UgyR8prLh2xfu"

--- a/pools/dpool.json
+++ b/pools/dpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "dpool",
+  "id": 51,
   "name": "DPOOL",
   "addresses": [
     "1ACAgPuFFidYzPMXbiKptSrwT74Dg8hq2v",

--- a/pools/eclipsemc.json
+++ b/pools/eclipsemc.json
@@ -1,5 +1,5 @@
 {
-  "id": "eclipsemc",
+  "id": 83,
   "name": "EclipseMC",
   "addresses": [
     "15xiShqUqerfjFdyfgBH1K7Gwp6cbYmsTW",

--- a/pools/ekanembtc.json
+++ b/pools/ekanembtc.json
@@ -1,5 +1,5 @@
 {
-  "id": "ekanembtc",
+  "id": 21,
   "name": "EkanemBTC",
   "addresses": [
     "1Cs5RT9SRk1hxsdzivAfkjesNmVVJqfqkw"

--- a/pools/eligius.json
+++ b/pools/eligius.json
@@ -1,5 +1,5 @@
 {
-  "id": "eligius",
+  "id": 33,
   "name": "Eligius",
   "addresses": [],
   "tags": [

--- a/pools/emcdpool.json
+++ b/pools/emcdpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "emcdpool",
+  "id": 3,
   "name": "EMCDPool",
   "addresses": [
     "1BDbsWi3Mrcjp1wdop3PWFNCNZtu4R7Hjy"

--- a/pools/eobot.json
+++ b/pools/eobot.json
@@ -1,5 +1,5 @@
 {
-  "id": "eobot",
+  "id": 92,
   "name": "Eobot",
   "addresses": [
     "16GsNC3q6KgVXkUX7j7aPxSUdHrt1sN2yN",

--- a/pools/exxbw.json
+++ b/pools/exxbw.json
@@ -1,5 +1,5 @@
 {
-  "id": "exx&bw",
+  "id": 137,
   "name": "EXX&BW",
   "addresses": [],
   "tags": [

--- a/pools/f2pool.json
+++ b/pools/f2pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "f2pool",
+  "id": 22,
   "name": "F2Pool",
   "addresses": [
     "1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY",

--- a/pools/foundry-usa.json
+++ b/pools/foundry-usa.json
@@ -1,5 +1,5 @@
 {
-  "id": "foundryusa",
+  "id": 88,
   "name": "Foundry USA",
   "addresses": [
     "12KKDt4Mj7N5UAkQMN7LtPZMayenXHa8KL",

--- a/pools/gbminers.json
+++ b/pools/gbminers.json
@@ -1,5 +1,5 @@
 {
-  "id": "gbminers",
+  "id": 130,
   "name": "GBMiners",
   "addresses": [],
   "tags": [

--- a/pools/ghash-io.json
+++ b/pools/ghash-io.json
@@ -1,5 +1,5 @@
 {
-  "id": "ghashio",
+  "id": 26,
   "name": "GHash.IO",
   "addresses": [
     "1CjPR7Z5ZSyWk6WtXvSFgkptmpoi4UM9BC"

--- a/pools/give-me-coins.json
+++ b/pools/give-me-coins.json
@@ -1,5 +1,5 @@
 {
-  "id": "givemecoins",
+  "id": 16,
   "name": "Give Me Coins",
   "addresses": [],
   "tags": [

--- a/pools/gogreenlight.json
+++ b/pools/gogreenlight.json
@@ -1,5 +1,5 @@
 {
-  "id": "gogreenlight",
+  "id": 86,
   "name": "GoGreenLight",
   "addresses": [
     "18EPLvrs2UE11kWBB3ABS7Crwj5tTBYPoa"

--- a/pools/haominer.json
+++ b/pools/haominer.json
@@ -1,5 +1,5 @@
 {
-  "id": "haominer",
+  "id": 87,
   "name": "haominer",
   "addresses": [],
   "tags": [

--- a/pools/haozhuzhu.json
+++ b/pools/haozhuzhu.json
@@ -1,5 +1,5 @@
 {
-  "id": "haozhuzhu",
+  "id": 94,
   "name": "HAOZHUZHU",
   "addresses": [
     "19qa95rTbDziNCS9EexUbh2hVY4viUU9tt"

--- a/pools/hashbx.json
+++ b/pools/hashbx.json
@@ -1,5 +1,5 @@
 {
-  "id": "hashbx",
+  "id": 38,
   "name": "HashBX",
   "addresses": [],
   "tags": [

--- a/pools/hashpool.json
+++ b/pools/hashpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "hashpool",
+  "id": 58,
   "name": "HASHPOOL",
   "addresses": [],
   "tags": [

--- a/pools/helix.json
+++ b/pools/helix.json
@@ -1,5 +1,5 @@
 {
-  "id": "helix",
+  "id": 17,
   "name": "Helix",
   "addresses": [],
   "tags": [

--- a/pools/hhtt.json
+++ b/pools/hhtt.json
@@ -1,5 +1,5 @@
 {
-  "id": "hhtt",
+  "id": 115,
   "name": "HHTT",
   "addresses": [],
   "tags": [

--- a/pools/hotpool.json
+++ b/pools/hotpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "hotpool",
+  "id": 121,
   "name": "HotPool",
   "addresses": [
     "17judvK4AC2M6KhaBbAEGw8CTKc9Pg8wup"

--- a/pools/hummerpool.json
+++ b/pools/hummerpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "hummerpool",
+  "id": 93,
   "name": "Hummerpool",
   "addresses": [],
   "tags": [

--- a/pools/huobi-pool.json
+++ b/pools/huobi-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "huobipool",
+  "id": 126,
   "name": "Huobi Pool",
   "addresses": [
     "18Zcyxqna6h7Z7bRjhKvGpr8HSfieQWXqj",

--- a/pools/kanopool.json
+++ b/pools/kanopool.json
@@ -1,5 +1,5 @@
 {
-  "id": "kanopool",
+  "id": 118,
   "name": "KanoPool",
   "addresses": [],
   "tags": [

--- a/pools/kncminer.json
+++ b/pools/kncminer.json
@@ -1,5 +1,5 @@
 {
-  "id": "kncminer",
+  "id": 80,
   "name": "KnCMiner",
   "addresses": [],
   "tags": [

--- a/pools/kucoin-pool.json
+++ b/pools/kucoin-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "kucoinpool",
+  "id": 71,
   "name": "KuCoin Pool",
   "addresses": [
     "1ArTPjj6pV3aNRhLPjJVPYoxB98VLBzUmb"

--- a/pools/lubian-com.json
+++ b/pools/lubian-com.json
@@ -1,5 +1,5 @@
 {
-  "id": "lubiancom",
+  "id": 96,
   "name": "Lubian.com",
   "addresses": [
     "34Jpa4Eu3ApoPVUKNTN2WeuXVVq1jzxgPi"

--- a/pools/luxor.json
+++ b/pools/luxor.json
@@ -1,5 +1,5 @@
 {
-  "id": "luxor",
+  "id": 4,
   "name": "Luxor",
   "addresses": [
     "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe"

--- a/pools/mara-pool.json
+++ b/pools/mara-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "marapool",
+  "id": 140,
   "name": "MARA Pool",
   "addresses": [
     "15MdAHnkxt9TMC2Rj595hsg8Hnv693pPBB",

--- a/pools/maxbtc.json
+++ b/pools/maxbtc.json
@@ -1,5 +1,5 @@
 {
-  "id": "maxbtc",
+  "id": 108,
   "name": "MaxBTC",
   "addresses": [],
   "tags": [

--- a/pools/megabigpower.json
+++ b/pools/megabigpower.json
@@ -1,5 +1,5 @@
 {
-  "id": "megabigpower",
+  "id": 39,
   "name": "MegaBigPower",
   "addresses": [
     "17JJ3oZyF4ShQMGukDjpMWhmooCjEvoVVB",

--- a/pools/minerium.json
+++ b/pools/minerium.json
@@ -1,5 +1,5 @@
 {
-  "id": "minerium",
+  "id": 8,
   "name": "Minerium",
   "addresses": [],
   "tags": [

--- a/pools/miningcity.json
+++ b/pools/miningcity.json
@@ -1,5 +1,5 @@
 {
-  "id": "miningcity",
+  "id": 78,
   "name": "MiningCity",
   "addresses": [
     "11wC5KcbgrWRBb43cwADdVrxgyF8mndVC"

--- a/pools/mmpool.json
+++ b/pools/mmpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "mmpool",
+  "id": 56,
   "name": "mmpool",
   "addresses": [],
   "tags": [

--- a/pools/mt-red.json
+++ b/pools/mt-red.json
@@ -1,5 +1,5 @@
 {
-  "id": "mtred",
+  "id": 77,
   "name": "Mt Red",
   "addresses": [],
   "tags": [

--- a/pools/multicoin-co.json
+++ b/pools/multicoin-co.json
@@ -1,5 +1,5 @@
 {
-  "id": "multicoinco",
+  "id": 29,
   "name": "MultiCoin.co",
   "addresses": [],
   "tags": [

--- a/pools/multipool.json
+++ b/pools/multipool.json
@@ -1,5 +1,5 @@
 {
-  "id": "multipool",
+  "id": 59,
   "name": "Multipool",
   "addresses": [
     "1MeffGLauEj2CZ18hRQqUauTXb9JAuLbGw"

--- a/pools/mybtccoin-pool.json
+++ b/pools/mybtccoin-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "mybtccoinpool",
+  "id": 46,
   "name": "myBTCcoin Pool",
   "addresses": [
     "151T7r1MhizzJV6dskzzUkUdr7V8JxV2Dx"

--- a/pools/nexious.json
+++ b/pools/nexious.json
@@ -1,5 +1,5 @@
 {
-  "id": "nexious",
+  "id": 68,
   "name": "Nexious",
   "addresses": [
     "1GBo1f2tzVx5jScV9kJXPUP9RjvYXuNzV7"

--- a/pools/nicehash.json
+++ b/pools/nicehash.json
@@ -1,5 +1,5 @@
 {
-  "id": "nicehash",
+  "id": 103,
   "name": "NiceHash",
   "addresses": [],
   "tags": [

--- a/pools/nmcbit.json
+++ b/pools/nmcbit.json
@@ -1,5 +1,5 @@
 {
-  "id": "nmcbit",
+  "id": 28,
   "name": "NMCbit",
   "addresses": [],
   "tags": [

--- a/pools/novablock.json
+++ b/pools/novablock.json
@@ -1,5 +1,5 @@
 {
-  "id": "novablock",
+  "id": 11,
   "name": "NovaBlock",
   "addresses": [
     "3Bmb9Jig8A5kHdDSxvDZ6eryj3AXd3swuJ"

--- a/pools/okexpool.json
+++ b/pools/okexpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "okexpool",
+  "id": 32,
   "name": "OKExPool",
   "addresses": [],
   "tags": [

--- a/pools/okkong.json
+++ b/pools/okkong.json
@@ -1,5 +1,5 @@
 {
-  "id": "okkong",
+  "id": 25,
   "name": "OKKONG",
   "addresses": [
     "16JHXJ7M2MubWNX9grnqbjUqJ5PHwcCWw2"

--- a/pools/okminer.json
+++ b/pools/okminer.json
@@ -1,5 +1,5 @@
 {
-  "id": "okminer",
+  "id": 5,
   "name": "OKMINER",
   "addresses": [
     "15xcAZ2HfaSwYbCV6GGbasBSAekBRRC5Q2"

--- a/pools/okpool-top.json
+++ b/pools/okpool-top.json
@@ -1,5 +1,5 @@
 {
-  "id": "okpooltop",
+  "id": 99,
   "name": "okpool.top",
   "addresses": [],
   "tags": [

--- a/pools/ozcoin.json
+++ b/pools/ozcoin.json
@@ -1,5 +1,5 @@
 {
-  "id": "ozcoin",
+  "id": 20,
   "name": "OzCoin",
   "addresses": [],
   "tags": [

--- a/pools/patels.json
+++ b/pools/patels.json
@@ -1,5 +1,5 @@
 {
-  "id": "patels",
+  "id": 30,
   "name": "Patels",
   "addresses": [
     "197miJmttpCt2ubVs6DDtGBYFDroxHmvVB",

--- a/pools/pega-pool.json
+++ b/pools/pega-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "pegapool",
+  "id": 74,
   "name": "Pega Pool",
   "addresses": [
     "1BGFwRzjCfRR7EvRHnzfHyFjGR8XiBDFKa"

--- a/pools/phash-io.json
+++ b/pools/phash-io.json
@@ -1,5 +1,5 @@
 {
-  "id": "phashio",
+  "id": 12,
   "name": "PHash.IO",
   "addresses": [],
   "tags": [

--- a/pools/polmine.json
+++ b/pools/polmine.json
@@ -1,5 +1,5 @@
 {
-  "id": "polmine",
+  "id": 57,
   "name": "Polmine",
   "addresses": [
     "13vWXwzNF5Ef9SUXNTdr7de7MqiV4G1gnL",

--- a/pools/poolin.json
+++ b/pools/poolin.json
@@ -1,5 +1,5 @@
 {
-  "id": "poolin",
+  "id": 111,
   "name": "Poolin",
   "addresses": [
     "14sA8jqYQgMRQV9zUtGFvpeMEw7YDn77SK",

--- a/pools/rawpool.json
+++ b/pools/rawpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "rawpool",
+  "id": 136,
   "name": "Rawpool",
   "addresses": [
     "35y82tEPDa2wm6tzkEacMG8GPPW7zbMj83",

--- a/pools/rigpool.json
+++ b/pools/rigpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "rigpool",
+  "id": 27,
   "name": "RigPool",
   "addresses": [
     "1JpKmtspBJQVXK67DJP64eBJcAPhDvJ9Er"

--- a/pools/sbi-crypto.json
+++ b/pools/sbi-crypto.json
@@ -1,5 +1,5 @@
 {
-  "id": "sbicrypto",
+  "id": 106,
   "name": "SBI Crypto",
   "addresses": [],
   "tags": [

--- a/pools/secretsuperstar.json
+++ b/pools/secretsuperstar.json
@@ -1,5 +1,5 @@
 {
-  "id": "secretsuperstar",
+  "id": 53,
   "name": "SecretSuperstar",
   "addresses": [],
   "tags": [

--- a/pools/shawnp0wers.json
+++ b/pools/shawnp0wers.json
@@ -1,5 +1,5 @@
 {
-  "id": "shawnp0wers",
+  "id": 52,
   "name": "shawnp0wers",
   "addresses": [
     "12znnESiJ3bgCLftwwrg9wzQKN8fJtoBDa",

--- a/pools/sigmapool-com.json
+++ b/pools/sigmapool-com.json
@@ -1,5 +1,5 @@
 {
-  "id": "sigmapoolcom",
+  "id": 48,
   "name": "Sigmapool.com",
   "addresses": [
     "12cKiMNhCtBhZRUBCnYXo8A4WQzMUtYjmR"

--- a/pools/simplecoin-us.json
+++ b/pools/simplecoin-us.json
@@ -1,5 +1,5 @@
 {
-  "id": "simplecoinus",
+  "id": 15,
   "name": "simplecoin.us",
   "addresses": [],
   "tags": [

--- a/pools/slushpool.json
+++ b/pools/slushpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "slush",
+  "id": 119,
   "name": "SlushPool",
   "addresses": [
     "1AqTMY7kmHZxBuLUR5wJjPFUvqGs23sesr",

--- a/pools/solo-ck.json
+++ b/pools/solo-ck.json
@@ -1,5 +1,5 @@
 {
-  "id": "solock",
+  "id": 66,
   "name": "Solo CK",
   "addresses": [],
   "tags": [

--- a/pools/spiderpool.json
+++ b/pools/spiderpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "spiderpool",
+  "id": 31,
   "name": "SpiderPool",
   "addresses": [
     "125m2H43pwKpSZjLhMQHneuTwTJN5qRyYu",

--- a/pools/st-mining-corp.json
+++ b/pools/st-mining-corp.json
@@ -1,5 +1,5 @@
 {
-  "id": "stminingcorp",
+  "id": 23,
   "name": "ST Mining Corp",
   "addresses": [],
   "tags": [

--- a/pools/tangpool.json
+++ b/pools/tangpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "tangpool",
+  "id": 60,
   "name": "Tangpool",
   "addresses": [
     "12Taz8FFXQ3E2AGn3ZW1SZM5bLnYGX4xR6"

--- a/pools/tatmas-pool.json
+++ b/pools/tatmas-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "tatmaspool",
+  "id": 55,
   "name": "TATMAS Pool",
   "addresses": [],
   "tags": [

--- a/pools/tbdice.json
+++ b/pools/tbdice.json
@@ -1,5 +1,5 @@
 {
-  "id": "tbdice",
+  "id": 113,
   "name": "TBDice",
   "addresses": [],
   "tags": [

--- a/pools/telco-214.json
+++ b/pools/telco-214.json
@@ -1,5 +1,5 @@
 {
-  "id": "telco214",
+  "id": 81,
   "name": "Telco 214",
   "addresses": [
     "13Sd8Y7nUao3z4bJFkZvCRXpFqHvLy49YY",

--- a/pools/terra-pool.json
+++ b/pools/terra-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "terrapool",
+  "id": 76,
   "name": "Terra Pool",
   "addresses": [
     "32P5KVSbZYAkVmSHxDd2oBXaSk372rbV7L",

--- a/pools/tigerpool.json
+++ b/pools/tigerpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "tigerpool",
+  "id": 89,
   "name": "Tiger Pool",
   "addresses": [
     "1LsFmhnne74EmU4q4aobfxfrWY4wfMVd8w"

--- a/pools/titan.json
+++ b/pools/titan.json
@@ -1,5 +1,5 @@
 {
-  "id": "titan",
+  "id": 84,
   "name": "Titan",
   "addresses": [
     "14hLEtxozmmih6Gg5xrGZLfx51bEMj21NW"

--- a/pools/tmspool.json
+++ b/pools/tmspool.json
@@ -1,5 +1,5 @@
 {
-  "id": "tmspool",
+  "id": 98,
   "name": "TMSPool",
   "addresses": [],
   "tags": [

--- a/pools/togetherpool.json
+++ b/pools/togetherpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "togetherpool",
+  "id": 18,
   "name": "TogetherPool",
   "addresses": [
     "bc1qwlrsvgtn99rqp3fgaxq6f6jkgms80rnej0a8tc"

--- a/pools/transactioncoinmining.json
+++ b/pools/transactioncoinmining.json
@@ -1,5 +1,5 @@
 {
-  "id": "transactioncoinmining",
+  "id": 44,
   "name": "transactioncoinmining",
   "addresses": [
     "1qtKetXKgqa7j1KrB19HbvfRiNUncmakk"

--- a/pools/trickys-btc-pool.json
+++ b/pools/trickys-btc-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "trickysbtcpool",
+  "id": 40,
   "name": "Tricky's BTC Pool",
   "addresses": [
     "1AePMyovoijxvHuKhTqWvpaAkRCF4QswC6"

--- a/pools/triplemining.json
+++ b/pools/triplemining.json
@@ -1,5 +1,5 @@
 {
-  "id": "triplemining",
+  "id": 10,
   "name": "TripleMining",
   "addresses": [],
   "tags": [

--- a/pools/ukrpool.json
+++ b/pools/ukrpool.json
@@ -1,5 +1,5 @@
 {
-  "id": "ukrpool",
+  "id": 14,
   "name": "UKRPool",
   "addresses": [
     "125K2xfiBdae42gSKiCGwi85Frpy1vHmGj"

--- a/pools/ultimus-pool.json
+++ b/pools/ultimus-pool.json
@@ -1,5 +1,5 @@
 {
-  "id": "ultimuspool",
+  "id": 72,
   "name": "Ultimus Pool",
   "addresses": [
     "1EMVSMe1VJUuqv7D7SFzctnVXk4KdjXATi",

--- a/pools/unomp.json
+++ b/pools/unomp.json
@@ -1,5 +1,5 @@
 {
-  "id": "unomp",
+  "id": 131,
   "name": "UNOMP",
   "addresses": [
     "1BRY8AD7vSNUEE75NjzfgiG18mWjGQSRuJ"

--- a/pools/viabtc.json
+++ b/pools/viabtc.json
@@ -1,5 +1,5 @@
 {
-  "id": "viabtc",
+  "id": 110,
   "name": "ViaBTC",
   "addresses": [],
   "tags": [

--- a/pools/waterhole.json
+++ b/pools/waterhole.json
@@ -1,5 +1,5 @@
 {
-  "id": "waterhole",
+  "id": 50,
   "name": "Waterhole",
   "addresses": [
     "1FLH1SoLv4U68yUERhDiWzrJn5TggMqkaZ"

--- a/pools/wayi-cn.json
+++ b/pools/wayi-cn.json
@@ -1,5 +1,5 @@
 {
-  "id": "wayicn",
+  "id": 124,
   "name": "WAYI.CN",
   "addresses": [],
   "tags": [

--- a/pools/yourbtc-net.json
+++ b/pools/yourbtc-net.json
@@ -1,5 +1,5 @@
 {
-  "id": "yourbtcnet",
+  "id": 42,
   "name": "Yourbtc.net",
   "addresses": [],
   "tags": [

--- a/qa/check-data.py
+++ b/qa/check-data.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import json
+import glob
+import sys
+
+entity_files = glob.glob("pools/*.json")
+
+ids = set()
+max_id = -1
+
+for file_path in entity_files:
+    with open(file_path, "r") as f:
+        e = json.load(f)
+
+        id = e["id"]
+        name = e["name"]
+        addresses = e["addresses"]
+        tags = e["tags"]
+        link = e["link"]
+
+        try:
+
+            id_already_used = id in ids
+            assert type(id) == int, "ID is not of type int"
+            assert not id_already_used, f"ID {id} is already used"
+            assert id != 0, f"ID should not be zero"
+            ids.add(id)
+            max_id = max(id, max_id)
+
+            assert type(name) == str, "mame is not of type string"
+
+            assert type(addresses) == list, "addresses is not of type list"
+            assert type(tags) == list, "tags is not of type list"
+
+            # we should have at least one tag or address
+            assert len(addresses) + len(tags) > 0, "addresses and tags both are empty"
+
+            assert type(link) == str, "link is not of type string"
+
+        except Exception as ex:
+            print(f"Invalid pool in file {file_path}.")
+            print(f"Pool: {json.dumps(e, indent=2, ensure_ascii=False)}")
+            raise ex
+
+print("No problems found.")
+print(f"The maximum ID is {max_id}.")
+print(f"Use ID {max_id + 1} when creating a new pool JSON file.")


### PR DESCRIPTION
See https://github.com/0xB10C/known-mining-pools/pull/75#issuecomment-1363169075. This also adds a basic check to the CI that there are no duplicate IDs and that the data has the expected format.

I used this script to change the IDs to integers:

```python3
#!/usr/bin/env python3

import json
import glob
import sys

entity_files = glob.glob("pools/*.json")

pool_id = 1

for file_path in entity_files:
    with open(file_path, "r") as f:
        e = json.load(f)

        content = {
            "id": pool_id,
            "name": e["name"],
            "addresses": sorted(e["addresses"]),
            "tags": sorted(e["tags"]),
            "link": e["link"],
        }

        with open(file_path, "w") as out:
            json.dump(content, out, indent=2, ensure_ascii=False)
            out.write('\n')
    pool_id+=1
```