### PR TITLE
rename: Slush Pool -> Braiins Pool

### DIFF
--- a/generated/pool-list.json
+++ b/generated/pool-list.json
@@ -1276,7 +1276,7 @@
   },
   {
     "id": 119,
-    "name": "SlushPool",
+    "name": "Braiins Pool",
     "addresses": [
       "1AqTMY7kmHZxBuLUR5wJjPFUvqGs23sesr",
       "1CK6KHY6MHgYvmRQ4PAafKYDrg1ejbH1cE"
@@ -1284,7 +1284,7 @@
     "tags": [
       "/slush/"
     ],
-    "link": "https://slushpool.com"
+    "link": "https://braiins.com/"
   },
   {
     "id": 120,

--- a/generated/pools.json
+++ b/generated/pools.json
@@ -265,8 +265,8 @@
       "link": "https://ckpool.org"
     },
     "1AqTMY7kmHZxBuLUR5wJjPFUvqGs23sesr": {
-      "name": "SlushPool",
-      "link": "https://slushpool.com"
+      "name": "Braiins Pool",
+      "link": "https://braiins.com/"
     },
     "1ArTPjj6pV3aNRhLPjJVPYoxB98VLBzUmb": {
       "name": "KuCoin Pool",
@@ -309,8 +309,8 @@
       "link": "https://104.197.8.250"
     },
     "1CK6KHY6MHgYvmRQ4PAafKYDrg1ejbH1cE": {
-      "name": "SlushPool",
-      "link": "https://slushpool.com"
+      "name": "Braiins Pool",
+      "link": "https://braiins.com/"
     },
     "1CNq2FAw6S5JfBiDkjkYJUVNQwjoeY4Zfi": {
       "name": "Telco 214",
@@ -1027,8 +1027,8 @@
       "link": "https://www.poolin.com"
     },
     "/slush/": {
-      "name": "SlushPool",
-      "link": "https://slushpool.com"
+      "name": "Braiins Pool",
+      "link": "https://braiins.com/"
     },
     "/solo.ckpool.org/": {
       "name": "Solo CK",

--- a/pools/braiins.json
+++ b/pools/braiins.json
@@ -1,6 +1,6 @@
 {
   "id": 119,
-  "name": "SlushPool",
+  "name": "Braiins Pool",
   "addresses": [
     "1AqTMY7kmHZxBuLUR5wJjPFUvqGs23sesr",
     "1CK6KHY6MHgYvmRQ4PAafKYDrg1ejbH1cE"
@@ -8,5 +8,5 @@
   "tags": [
     "/slush/"
   ],
-  "link": "https://slushpool.com"
+  "link": "https://braiins.com/"
 }


### PR DESCRIPTION
Slush Pool was rebranded to Braiins Pool.
https://pool.braiins.com/en/news/goodbye-slush-pool/

closes #77