### PR TITLE
add: GDPool (Lucky pool)

### DIFF
--- a/pools/gdpool.json
+++ b/pools/gdpool.json
@@ -1,0 +1,12 @@
+{
+  "id": 154,
+  "name": "GDPool",
+  "addresses": [
+    "1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1"
+  ],
+  "tags": [
+    "GDPool",
+    "Lucky pool"
+  ],
+  "link": "https://mempool.space/mining/pool/gdpool"
+}


### PR DESCRIPTION
## Summary

This adds `GDPool` to the mining pool dataset with tags `GDPool` and `Lucky pool`, paying to [`1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1`](https://mempool.space/address/1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1). Both tags are required: the operator rebranded from `Lucky pool` to `GDPool` on the same payout address, and keeping both ensures historical blocks stay attributed.

Closes #101.

## Context

`GDPool` and `Lucky pool` are the same pool, not two distinct operators. The parallel [`mempool/mining-pools`](https://github.com/mempool/mining-pools) dataset carried this pool as `luckyPool` until [PR #90](https://github.com/mempool/mining-pools/pull/90) (merged 2025-11-26) renamed the entry to `GDPool`, keeping the same pool id, the same single payout address, and the `Lucky pool` regex alongside the new `GDPool` regex. Block [`903840`](https://mempool.space/block/0000000000000000000000a281d8ccede6b1a00f861abca6bb71964c003eb7ae) carries the `Lucky pool` coinbase text while later blocks carry `GDPool`, all paying the same address.

Issue #101 also mentions `Miningcore` as a candidate name. The earliest three blocks from this operator (heights [`808964`](https://mempool.space/block/00000000000000000002535c56c5051737a830648218f75ddd587e8b144c5d62), [`810717`](https://mempool.space/block/00000000000000000003f09e007da082ae7bcee58c458803a8cfe32c8e50f8a3), [`812535`](https://mempool.space/block/00000000000000000003e4e96a2fe786dc1ed4a0c5b3ffbfa7984d51f49961ac), Sept–Oct 2023) do carry a `Miningcore` coinbase tag, but `Miningcore` is the default string emitted by the open-source [Miningcore](https://github.com/oliverw/miningcore) pool software rather than a pool name/branc. Adding it as a tag here would mis-attribute any other self-hosted Miningcore BTC pool to GDPool (if there are any, haven't checked); the three blocks in question already pay [`1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1`](https://mempool.space/address/1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1) and are therefore attributed via the address match regardless.

## Evidence

Coinbase tag evidence for `GDPool`:

- [block `906701`](https://mempool.space/block/00000000000000000001a5b9d2ccb9aef66657521b7a366094c5f952bc125dec): scriptSig ends with `064744506f6f6c` (`GDPool`), pays to [`1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1`](https://mempool.space/address/1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1)
- [block `908662`](https://mempool.space/block/00000000000000000001ac960a909611e76bad61c248983f1c3e8b3149c419f7): scriptSig ends with `064744506f6f6c` (`GDPool`), pays to [`1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1`](https://mempool.space/address/1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1)

Coinbase tag evidence for `Lucky pool`:

- [block `903840`](https://mempool.space/block/0000000000000000000000a281d8ccede6b1a00f861abca6bb71964c003eb7ae): scriptSig ends with `0a4c75636b7920706f6f6c` (`Lucky pool`), pays to [`1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1`](https://mempool.space/address/1DnPPFQPrfyNTiHPXhDFyqNnW9T62GEhB1)

## Testing

- `python3 qa/check-data.py`
- `python3 contrib/generate-old-pools-json.py`