### PR TITLE
Add OwnBlock mining pool

### DIFF
--- a/pools/ownblock.json
+++ b/pools/ownblock.json
@@ -1,0 +1,9 @@
+{
+  "id": 154,
+  "name": "OwnBlock",
+  "addresses": [],
+  "tags": [
+    "/ownblock/"
+  ],
+  "link": "https://ownblock.io"
+}


### PR DESCRIPTION
Adds OwnBlock (https://ownblock.io), a cryptocurrency mining pool supporting Bitcoin Cash, Bitcoin and Monero.

Coinbase tag: `/ownblock/`

Block: 952870