### PR TITLE
Add SoloLuck (Asia-based solo Bitcoin pool)

### DIFF
--- a/pools/sololuck.json
+++ b/pools/sololuck.json
@@ -1,0 +1,9 @@
+{
+  "id": 154,
+  "name": "SoloLuck",
+  "addresses": [],
+  "tags": [
+    "/sololuck.io/"
+  ],
+  "link": "https://sololuck.io"
+}

--- a/pools/sololuck.json
+++ b/pools/sololuck.json
@@ -1,7 +1,9 @@
 {
   "id": 154,
   "name": "SoloLuck",
-  "addresses": [],
+  "addresses": [
+    "bc1q9t8v8e29xhhxlj3tt5ulj4dxal8ud3wreessha"
+  ],
   "tags": [
     "/sololuck.io/"
   ],

--- a/pools/sololuck.json
+++ b/pools/sololuck.json
@@ -1,9 +1,7 @@
 {
   "id": 154,
   "name": "SoloLuck",
-  "addresses": [
-    "bc1q9t8v8e29xhhxlj3tt5ulj4dxal8ud3wreessha"
-  ],
+  "addresses": [],
   "tags": [
     "/sololuck.io/"
   ],


### PR DESCRIPTION
Adds **SoloLuck** — a public true-solo Bitcoin pool (Asia / Jakarta, ckpool-based, 2% fee on a solved block).

- Coinbase tag: `/sololuck.io/` (the pool's configured ckpool `btcsig`; verified present in the live coinbase scriptSig).
- Homepage: https://sololuck.io
- Tag-only entry (no payout address), mirroring the style of `solo-ck.json`.

New pool — no blocks found yet (solo mining is a lottery), so the entry is keyed on the coinbase tag. Happy to add the payout address or cite the first solved block's coinbase if a maintainer prefers.